### PR TITLE
fix(carbium): correct v1/v2 API params, remove dead v2 endpoints

### DIFF
--- a/skills/carbium/SKILL.md
+++ b/skills/carbium/SKILL.md
@@ -611,6 +611,7 @@ These endpoints are still operational but use the older parameter family. Do not
 | `/api/v1/quote/all` | GET | `fromMint`, `toMint`, `amount`, `slippage` | Compare quotes across all providers |
 | `/api/v1/swap` | GET | `owner`, `fromMint`, `toMint`, `amount`, `slippage`, `provider` + optional flags | Get serialized swap transaction |
 | `/api/v1/swap/bundle` | GET | `signedTransaction` | Submit via Jito bundle (MEV protection) |
+| `/api/v1/fee/custom` | GET | `payer`, `receiver`, `lamports` | Generate custom fee transfer transaction |
 
 v1 `/swap` supports additional execution flags: `gasless`, `mevSafe`, `priorityMicroLamports`, `feeLamports`, `feeReceiver`, `pool`.
 

--- a/skills/carbium/SKILL.md
+++ b/skills/carbium/SKILL.md
@@ -525,21 +525,22 @@ For complete gRPC reference with response shapes, see `resources/grpc-reference.
 
 Aggregated DEX quotes and execution powered by the CQ1 engine — sub-millisecond quotes, ~10ms chain-to-queryable latency, binary-native state.
 
-**Base URL:** `https://api.carbium.io/api/v2`
+**Base URL:** `https://api.carbium.io`
 **Auth:** `X-API-KEY: YOUR_API_KEY` header on all requests
 **Get your key:** [api.carbium.io/login](https://api.carbium.io/login) (free account)
 
-### Endpoints
+### API Versions
 
-| Endpoint | Method | Description |
+| Version | Surface | Status |
 |---|---|---|
-| `/quote` | GET | Get optimized quote with optional executable transaction |
-| `/quote/all` | GET | Compare quotes from all supported DEX providers |
-| `/swap` | GET | Get serialized swap transaction for a specific provider |
-| `/swap/bundle` | GET | Submit signed transaction via Jito bundle (MEV protection) |
-| `/fee/custom` | GET | Generate custom fee transfer transaction |
+| **v2 (Q1)** | `GET /api/v2/quote` | **Current — use this for new integrations** |
+| v1 (legacy) | `GET /api/v1/quote`, `/api/v1/swap`, `/api/v1/quote/all`, `/api/v1/swap/bundle` | Legacy — still operational |
 
-### 1. Get Quote
+> **Important:** v2 and v1 use different parameter names. Do not mix them. v2 (Q1) uses `src_mint`/`dst_mint`/`amount_in`/`slippage_bps`. v1 uses `fromMint`/`toMint`/`amount`/`slippage`.
+
+### v2 / Q1 — Quote + Executable Transaction (Recommended)
+
+The Q1 engine returns both the quote **and** an executable transaction in a single call when `user_account` is included. No separate swap endpoint needed.
 
 ```
 GET /api/v2/quote
@@ -551,7 +552,9 @@ GET /api/v2/quote
 | `dst_mint` | Yes | Output token mint address |
 | `amount_in` | Yes | Input amount in smallest unit (lamports) |
 | `slippage_bps` | Yes | Slippage tolerance in basis points |
-| `user_account` | No | If included, response includes a `txn` field (base64 serialized transaction) |
+| `user_account` | No | Wallet address — if included, response includes executable `txn` field |
+
+**Quote only (no transaction):**
 
 ```typescript
 const quote = await fetch(
@@ -562,6 +565,23 @@ const quote = await fetch(
   "&slippage_bps=100",
   { headers: { "X-API-KEY": process.env.CARBIUM_API_KEY! } }
 ).then(r => r.json());
+// Returns: { srcAmountIn, destAmountOut, destAmountOutMin, priceImpactPct, routePlan }
+```
+
+**Quote + executable transaction (include `user_account`):**
+
+```typescript
+const quote = await fetch(
+  "https://api.carbium.io/api/v2/quote" +
+  "?src_mint=So11111111111111111111111111111111111111112" +
+  "&dst_mint=EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v" +
+  "&amount_in=1000000000" +
+  "&slippage_bps=100" +
+  "&user_account=YOUR_WALLET_ADDRESS",
+  { headers: { "X-API-KEY": process.env.CARBIUM_API_KEY! } }
+).then(r => r.json());
+// Returns: { srcAmountIn, destAmountOut, destAmountOutMin, priceImpactPct, routePlan, txn }
+// txn is base64-encoded, ready for deserialization and signing
 ```
 
 ```python
@@ -574,77 +594,27 @@ resp = httpx.get(
         "dst_mint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
         "amount_in": 1_000_000_000,
         "slippage_bps": 100,
+        "user_account": "YOUR_WALLET_ADDRESS",  # include for executable txn
     },
     headers={"X-API-KEY": os.environ["CARBIUM_API_KEY"]},
 )
 print(resp.json())
 ```
 
-### 2. Compare All Providers
+### v1 Legacy Endpoints
 
-```
-GET /api/v2/quote/all
-```
+These endpoints are still operational but use the older parameter family. Do not mix v1 params with v2 URLs.
 
-| Param | Required | Description |
-|---|---|---|
-| `fromMint` | Yes | Input token mint |
-| `toMint` | Yes | Output token mint |
-| `amount` | Yes | Input amount in smallest unit |
-| `slippage` | Yes | Slippage in basis points |
+| Endpoint | Method | Params | Description |
+|---|---|---|---|
+| `/api/v1/quote` | GET | `fromMint`, `toMint`, `amount`, `slippage`, `provider` | Provider-specific quote |
+| `/api/v1/quote/all` | GET | `fromMint`, `toMint`, `amount`, `slippage` | Compare quotes across all providers |
+| `/api/v1/swap` | GET | `owner`, `fromMint`, `toMint`, `amount`, `slippage`, `provider` + optional flags | Get serialized swap transaction |
+| `/api/v1/swap/bundle` | GET | `signedTransaction` | Submit via Jito bundle (MEV protection) |
 
-Returns quotes from all supported DEX providers for comparison.
+v1 `/swap` supports additional execution flags: `gasless`, `mevSafe`, `priorityMicroLamports`, `feeLamports`, `feeReceiver`, `pool`.
 
-### 3. Get Swap Transaction
-
-```
-GET /api/v2/swap
-```
-
-| Param | Required | Description |
-|---|---|---|
-| `owner` | Yes | Wallet address of the user |
-| `fromMint` | Yes | Input token mint |
-| `toMint` | Yes | Output token mint |
-| `amount` | Yes | Input amount in smallest unit |
-| `slippage` | Yes | Slippage in basis points |
-| `provider` | Yes | DEX provider to route through |
-| `pool` | No | Custom pool address |
-| `feeLamports` | No | Custom fee amount in lamports |
-| `feeReceiver` | No | Custom fee recipient (required if feeLamports set) |
-| `priorityMicroLamports` | No | Compute unit price for priority fees |
-| `mevSafe` | No | If true, includes Jito tip instruction |
-| `gasless` | No | If true, gasless swap (output token must be SOL) |
-
-Returns a base64-encoded serialized transaction. Deserialize, sign, then submit via RPC.
-
-> **Naming inconsistency warning:** Quote uses `src_mint`/`dst_mint`/`amount_in`/`slippage_bps`. Swap uses `fromMint`/`toMint`/`amount`/`slippage`. Use the exact param names per endpoint.
-
-### 4. Jito Bundle (MEV-Protected Execution)
-
-```
-GET /api/v2/swap/bundle
-```
-
-| Param | Required | Description |
-|---|---|---|
-| `signedTransaction` | Yes | Base64-encoded signed transaction |
-
-Returns bundle ID and transaction hash. Routes through Jito for MEV protection without requiring a separate Jito SDK.
-
-### 5. Custom Fee Transaction
-
-```
-GET /api/v2/fee/custom
-```
-
-| Param | Required | Description |
-|---|---|---|
-| `payer` | Yes | Address of the fee payer |
-| `receiver` | Yes | Address of the fee receiver |
-| `lamports` | Yes | Fee amount in lamports |
-
-### Full Swap Execute Flow (TypeScript)
+### Full Swap Execute Flow (TypeScript) — v2/Q1
 
 ```typescript
 import { Connection, VersionedTransaction, Keypair } from "@solana/web3.js";
@@ -654,19 +624,22 @@ const connection = new Connection(
   "confirmed"
 );
 
-// 1. Get swap transaction
-const res = await fetch(
-  "https://api.carbium.io/api/v2/swap" +
-  "?owner=YOUR_WALLET_ADDRESS" +
-  "&fromMint=So11111111111111111111111111111111111111112" +
-  "&toMint=EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v" +
-  "&amount=100000000&slippage=100&provider=raydium",
-  { headers: { accept: "text/plain", "X-API-KEY": process.env.CARBIUM_API_KEY! } }
-);
-const { transaction } = await res.json();
+// 1. Get quote with executable transaction (single call)
+const url = new URL("https://api.carbium.io/api/v2/quote");
+url.searchParams.set("src_mint", "So11111111111111111111111111111111111111112");
+url.searchParams.set("dst_mint", "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");
+url.searchParams.set("amount_in", "100000000");
+url.searchParams.set("slippage_bps", "100");
+url.searchParams.set("user_account", "YOUR_WALLET_ADDRESS");
+
+const quote = await fetch(url, {
+  headers: { "X-API-KEY": process.env.CARBIUM_API_KEY! },
+}).then(r => r.json());
+
+if (!quote.txn) throw new Error("No executable transaction — check user_account param");
 
 // 2. Deserialize and sign
-const tx = VersionedTransaction.deserialize(Buffer.from(transaction, "base64"));
+const tx = VersionedTransaction.deserialize(Buffer.from(quote.txn, "base64"));
 // tx.sign([yourKeypair]);
 
 // 3. Submit via RPC
@@ -718,7 +691,7 @@ Gasless swaps let users execute on-chain transactions without holding SOL to pay
 
 ### Constraint
 
-Gasless swaps require the **output token to be SOL**. Set `gasless: true` on the `/swap` endpoint.
+Gasless swaps require the **output token to be SOL**. Currently available on the v1 swap endpoint.
 
 ### When to Use
 
@@ -728,11 +701,11 @@ Gasless swaps require the **output token to be SOL**. Set `gasless: true` on the
 
 ### Integration
 
-Add `gasless=true` to your swap request:
+Add `gasless=true` to a v1 swap request:
 
 ```typescript
 const res = await fetch(
-  "https://api.carbium.io/api/v2/swap" +
+  "https://api.carbium.io/api/v1/swap" +
   "?owner=WALLET&fromMint=USDC_MINT&toMint=SOL_MINT" +
   "&amount=1000000&slippage=100&provider=raydium&gasless=true",
   { headers: { "X-API-KEY": process.env.CARBIUM_API_KEY! } }
@@ -939,14 +912,16 @@ const connection = new Connection(
 
 ### From Jupiter Swap API
 
-Parameter mapping:
+Parameter mapping (v2/Q1):
 
-| Jupiter | Carbium Quote | Carbium Swap |
-|---|---|---|
-| `inputMint` | `src_mint` | `fromMint` |
-| `outputMint` | `dst_mint` | `toMint` |
-| `amount` | `amount_in` | `amount` |
-| `slippageBps` | `slippage_bps` | `slippage` |
+| Jupiter | Carbium v2/Q1 (`/api/v2/quote`) |
+|---|---|
+| `inputMint` | `src_mint` |
+| `outputMint` | `dst_mint` |
+| `amount` | `amount_in` |
+| `slippageBps` | `slippage_bps` |
+
+Key difference: Carbium Q1 returns the executable transaction in the quote response when `user_account` is included. No separate swap call needed.
 
 ### From Triton gRPC
 

--- a/skills/carbium/examples/gasless-swap/README.md
+++ b/skills/carbium/examples/gasless-swap/README.md
@@ -2,6 +2,8 @@
 
 Execute a token swap where Carbium covers the network fee. Output token must be SOL.
 
+> **Note:** Gasless swaps currently use the v1 swap endpoint (`/api/v1/swap`) with the `gasless=true` flag.
+
 ## Prerequisites
 
 ```bash
@@ -26,7 +28,8 @@ const USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
 
 async function gaslessSwap(wallet: Keypair, usdcAmount: number) {
   // Output MUST be SOL for gasless to work
-  const url = new URL("https://api.carbium.io/api/v2/swap");
+  // Gasless uses v1 swap endpoint with fromMint/toMint params
+  const url = new URL("https://api.carbium.io/api/v1/swap");
   url.searchParams.set("owner", wallet.publicKey.toBase58());
   url.searchParams.set("fromMint", USDC_MINT);
   url.searchParams.set("toMint", SOL_MINT);

--- a/skills/carbium/examples/swap-bundle/README.md
+++ b/skills/carbium/examples/swap-bundle/README.md
@@ -2,6 +2,8 @@
 
 Execute a swap with Jito MEV protection using the Carbium Swap API. No separate Jito SDK required.
 
+> **Note:** Bundle submission currently uses the v1 endpoints (`/api/v1/swap` with `mevSafe=true` + `/api/v1/swap/bundle`).
+
 ## Prerequisites
 
 ```bash
@@ -22,7 +24,7 @@ const connection = new Connection(
 
 const API_KEY = process.env.CARBIUM_API_KEY!;
 
-// Step 1: Get swap transaction with MEV safety
+// Step 1: Get swap transaction with MEV safety (v1 endpoint)
 async function getSwapTx(
   owner: string,
   fromMint: string,
@@ -31,7 +33,7 @@ async function getSwapTx(
   slippage: number,
   provider: string
 ) {
-  const url = new URL("https://api.carbium.io/api/v2/swap");
+  const url = new URL("https://api.carbium.io/api/v1/swap");
   url.searchParams.set("owner", owner);
   url.searchParams.set("fromMint", fromMint);
   url.searchParams.set("toMint", toMint);
@@ -57,9 +59,9 @@ function signTransaction(base64Tx: string, wallet: Keypair): string {
   return Buffer.from(tx.serialize()).toString("base64");
 }
 
-// Step 3: Submit via Jito bundle
+// Step 3: Submit via Jito bundle (v1 endpoint)
 async function submitBundle(signedBase64: string) {
-  const url = new URL("https://api.carbium.io/api/v2/swap/bundle");
+  const url = new URL("https://api.carbium.io/api/v1/swap/bundle");
   url.searchParams.set("signedTransaction", signedBase64);
 
   const res = await fetch(url, {

--- a/skills/carbium/examples/swap-quote/README.md
+++ b/skills/carbium/examples/swap-quote/README.md
@@ -1,6 +1,6 @@
-# Swap Quote — Quote → Swap → Sign → Submit
+# Swap Quote — Quote + Execute in One Call (v2/Q1)
 
-Full swap flow using the Carbium Swap API: get a quote, fetch the swap transaction, sign it, and submit via RPC.
+Full swap flow using Carbium's Q1 engine: get a quote with executable transaction, sign it, and submit via RPC. Single API call — no separate swap endpoint needed.
 
 ## Prerequisites
 
@@ -24,13 +24,14 @@ const API_KEY = process.env.CARBIUM_API_KEY!;
 const SOL_MINT = "So11111111111111111111111111111111111111112";
 const USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
 
-// Step 1: Get quote
-async function getQuote(amountLamports: number) {
+// Step 1: Get quote with executable transaction
+async function getQuoteWithTx(walletAddress: string, amountLamports: number) {
   const url = new URL("https://api.carbium.io/api/v2/quote");
   url.searchParams.set("src_mint", SOL_MINT);
   url.searchParams.set("dst_mint", USDC_MINT);
   url.searchParams.set("amount_in", amountLamports.toString());
   url.searchParams.set("slippage_bps", "100");
+  url.searchParams.set("user_account", walletAddress); // triggers txn in response
 
   const res = await fetch(url, {
     headers: { "X-API-KEY": API_KEY },
@@ -40,36 +41,25 @@ async function getQuote(amountLamports: number) {
   return res.json();
 }
 
-// Step 2: Get swap transaction
-async function getSwapTx(ownerAddress: string, amountLamports: number) {
-  const url = new URL("https://api.carbium.io/api/v2/swap");
-  url.searchParams.set("owner", ownerAddress);
-  url.searchParams.set("fromMint", SOL_MINT);
-  url.searchParams.set("toMint", USDC_MINT);
-  url.searchParams.set("amount", amountLamports.toString());
-  url.searchParams.set("slippage", "100");
-  url.searchParams.set("provider", "raydium");
-
-  const res = await fetch(url, {
-    headers: { accept: "text/plain", "X-API-KEY": API_KEY },
-  });
-
-  if (!res.ok) throw new Error(`Swap failed: ${res.status}`);
-  return res.json();
-}
-
-// Step 3: Sign and submit
+// Step 2: Sign and submit
 async function executeSwap(wallet: Keypair, amountLamports: number) {
-  const quote = await getQuote(amountLamports);
-  console.log("Quote:", quote);
-
-  const { transaction } = await getSwapTx(
+  const quote = await getQuoteWithTx(
     wallet.publicKey.toBase58(),
     amountLamports
   );
+  console.log("Quote:", {
+    in: quote.srcAmountIn,
+    out: quote.destAmountOut,
+    minOut: quote.destAmountOutMin,
+    route: quote.routePlan,
+  });
+
+  if (!quote.txn) {
+    throw new Error("No executable transaction — ensure user_account is set");
+  }
 
   const tx = VersionedTransaction.deserialize(
-    Buffer.from(transaction, "base64")
+    Buffer.from(quote.txn, "base64")
   );
   tx.sign([wallet]);
 

--- a/skills/carbium/resources/endpoints-and-auth.md
+++ b/skills/carbium/resources/endpoints-and-auth.md
@@ -19,7 +19,7 @@
 | Key | Signup | Covers |
 |---|---|---|
 | RPC Key | [rpc.carbium.io/signup](https://rpc.carbium.io/signup) | RPC + Standard WebSocket + gRPC |
-| Swap API Key | [api.carbium.io/login](https://api.carbium.io/login) | All `/api/v2/*` endpoints |
+| Swap API Key | [api.carbium.io/login](https://api.carbium.io/login) | All `/api/v1/*` and `/api/v2/*` endpoints |
 
 Programmatic key provisioning is not yet available. Keys are created via dashboards (free to start).
 

--- a/skills/carbium/resources/swap-api-reference.md
+++ b/skills/carbium/resources/swap-api-reference.md
@@ -99,9 +99,7 @@ Submit a signed transaction via Jito bundle for MEV protection.
 
 **Response:** JSON with bundle ID and transaction hash.
 
----
-
-## GET /api/v2/fee/custom
+### GET /api/v1/fee/custom
 
 Generate a custom fee transfer transaction.
 

--- a/skills/carbium/resources/swap-api-reference.md
+++ b/skills/carbium/resources/swap-api-reference.md
@@ -1,11 +1,21 @@
 # Carbium Swap API Reference
 
-Base URL: `https://api.carbium.io/api/v2`
 Auth: `X-API-KEY` header on all requests
 
-## GET /quote
+## API Versions
 
-Get optimized quote with optional executable transaction.
+| Version | Base URL | Parameters | Status |
+|---|---|---|---|
+| **v2 (Q1)** | `https://api.carbium.io/api/v2` | `src_mint`, `dst_mint`, `amount_in`, `slippage_bps` | **Current** |
+| v1 (legacy) | `https://api.carbium.io/api/v1` | `fromMint`, `toMint`, `amount`, `slippage` | Operational, legacy |
+
+> **Do not mix parameter families across versions.** Sending `fromMint` to a v2 endpoint or `src_mint` to a v1 endpoint will fail or return bad results.
+
+---
+
+## v2 — GET /api/v2/quote (Q1 Engine)
+
+Get optimized quote with optional executable transaction. **This is the recommended integration path.**
 
 | Param | Type | Required | Description |
 |---|---|---|---|
@@ -15,11 +25,39 @@ Get optimized quote with optional executable transaction.
 | `slippage_bps` | integer | Yes | Slippage tolerance in basis points (100 = 1%) |
 | `user_account` | string | No | User wallet address. If included, response includes `txn` field with base64 serialized transaction ready for signing |
 
-**Response:** JSON with quote details. If `user_account` provided, includes `txn` field.
+**Response fields:**
+
+| Field | Description |
+|---|---|
+| `srcAmountIn` | Confirmed raw input amount |
+| `destAmountOut` | Expected output amount |
+| `destAmountOutMin` | Minimum output after slippage |
+| `priceImpactPct` | Price impact percentage |
+| `routePlan` | Array of route steps (swap provider + percent) |
+| `txn` | Base64 transaction payload (only when `user_account` is present) |
+
+**Key insight:** Include `user_account` to get the executable transaction in the same call. No separate swap endpoint needed for v2 integrations.
 
 ---
 
-## GET /quote/all
+## v1 — Legacy Endpoints
+
+These endpoints are still operational and required for features not yet available on v2.
+
+### GET /api/v1/quote
+
+Provider-specific quote.
+
+| Param | Type | Required | Description |
+|---|---|---|---|
+| `fromMint` | string | Yes | Input token mint address |
+| `toMint` | string | Yes | Output token mint address |
+| `amount` | integer | Yes | Input amount in smallest unit |
+| `slippage` | integer | Yes | Slippage in basis points |
+| `provider` | string | Yes | DEX provider to route through |
+| `pool` | string | No | Custom pool address |
+
+### GET /api/v1/quote/all
 
 Compare quotes from all supported DEX providers simultaneously.
 
@@ -30,13 +68,7 @@ Compare quotes from all supported DEX providers simultaneously.
 | `amount` | integer | Yes | Input amount in smallest unit |
 | `slippage` | integer | Yes | Slippage in basis points |
 
-**Response:** JSON with quotes from each available provider for the given pair.
-
-> **Note:** This endpoint uses `fromMint`/`toMint` naming (like `/swap`), not `src_mint`/`dst_mint` (like `/quote`).
-
----
-
-## GET /swap
+### GET /api/v1/swap
 
 Get a serialized swap transaction for a specific provider.
 
@@ -47,7 +79,7 @@ Get a serialized swap transaction for a specific provider.
 | `toMint` | string | Yes | Output token mint address |
 | `amount` | integer | Yes | Input amount in smallest unit |
 | `slippage` | integer | Yes | Slippage in basis points |
-| `provider` | string | Yes | DEX provider to route through (see supported list below) |
+| `provider` | string | Yes | DEX provider to route through |
 | `pool` | string | No | Custom pool address for direct routing |
 | `feeLamports` | integer | No | Custom fee amount in lamports |
 | `feeReceiver` | string | No | Account receiving the custom fee (required if `feeLamports` set) |
@@ -57,13 +89,7 @@ Get a serialized swap transaction for a specific provider.
 
 **Response:** base64-encoded serialized `VersionedTransaction`. Deserialize → sign → submit via RPC.
 
-**Error responses:**
-- `400`: `{ error: { message: "No pool found" } }` — invalid pair or no liquidity
-- `401`: `{ error: { message: "API Key not found" } }` — missing/invalid key
-
----
-
-## GET /swap/bundle
+### GET /api/v1/swap/bundle
 
 Submit a signed transaction via Jito bundle for MEV protection.
 
@@ -73,11 +99,9 @@ Submit a signed transaction via Jito bundle for MEV protection.
 
 **Response:** JSON with bundle ID and transaction hash.
 
-**Flow:** Get transaction from `/swap` → sign locally → submit via `/swap/bundle`.
-
 ---
 
-## GET /fee/custom
+## GET /api/v2/fee/custom
 
 Generate a custom fee transfer transaction.
 
@@ -108,18 +132,15 @@ Generate a custom fee transfer transaction.
 
 ---
 
-## Naming Inconsistency Warning
+## Parameter Mapping Across Versions
 
-The Quote and Swap endpoints use **different parameter names** for the same concepts:
-
-| Concept | `/quote` param | `/swap` param |
+| Concept | v2/Q1 (`/api/v2/quote`) | v1 (`/api/v1/*`) |
 |---|---|---|
 | Input token | `src_mint` | `fromMint` |
 | Output token | `dst_mint` | `toMint` |
 | Amount | `amount_in` | `amount` |
 | Slippage | `slippage_bps` | `slippage` |
-
-Use the exact parameter names for each endpoint. Mismatched names will return silent bad results or errors.
+| Get executable tx | Include `user_account` in quote | Separate `/api/v1/swap` call |
 
 ---
 


### PR DESCRIPTION
## Summary

- **Remove 3 documented endpoints that return 404** — `/api/v2/swap`, `/api/v2/quote/all`, `/api/v2/swap/bundle` do not exist (confirmed via live API testing, all return HTTP 404)
- **Fix v1 parameter names on v2 endpoints** — sending `fromMint` to `/api/v2/quote` hard-fails with `"Failed to deserialize query string: missing field src_mint"`. The original docs framed this as a "naming inconsistency" — it's actually a v1 vs v2 version boundary
- **Document Q1 single-call flow** — v2/Q1 returns an executable `txn` in the quote response when `user_account` is included. No separate swap endpoint needed

### What changed

| File | Change |
|---|---|
| `SKILL.md` | Replaced "naming inconsistency" warning with v1/v2 version table. Removed dead v2 endpoints. Updated all v2 examples to use `src_mint`/`dst_mint`/`amount_in`/`slippage_bps`. Added Q1 single-call flow with `user_account` |
| `resources/swap-api-reference.md` | Full rewrite with separate v2 and v1 sections. Added parameter mapping table |
| `examples/swap-quote/README.md` | Rewritten from two-step (quote → swap) to Q1 single-call flow |
| `examples/gasless-swap/README.md` | Updated URL from `/api/v2/swap` → `/api/v1/swap` (where gasless actually works) |
| `examples/swap-bundle/README.md` | Updated URLs to correct v1 endpoints (`/api/v1/swap` + `/api/v1/swap/bundle`) |

### Verified against live API

- `GET /api/v2/quote?src_mint=...&dst_mint=...&amount_in=...&slippage_bps=...` ✅
- `GET /api/v2/swap` → 404 ❌ (removed)
- `GET /api/v1/quote` ✅
- `GET /api/v1/swap` ✅  
- `GET /api/v1/quote/all` ✅
- `GET /api/v1/swap/bundle` ✅

## Test plan

- [ ] Verify v2/Q1 quote call with `src_mint`/`dst_mint`/`amount_in`/`slippage_bps` returns valid response
- [ ] Verify v2/Q1 quote call with `user_account` returns `txn` field (base64 unsigned VersionedTransaction)
- [ ] Verify v1 endpoints still work with `fromMint`/`toMint`/`amount`/`slippage`
- [ ] Confirm no remaining references to `/api/v2/swap`, `/api/v2/quote/all`, or `/api/v2/swap/bundle`

🤖 Generated with [Claude Code](https://claude.com/claude-code)