### PR TITLE
fix: sync marketplace with repo and add validation ci

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -46,12 +46,6 @@
       "category": "Trading"
     },
     {
-      "name": "drift",
-      "source": "./skills/drift",
-      "description": "Drift Protocol SDK for perpetual futures, spot trading, cross-collateral, and vaults",
-      "category": "DeFi"
-    },
-    {
       "name": "glam",
       "source": "./skills/glam",
       "description": "GLAM Protocol for tokenized vaults, DeFi integrations (Jupiter, Drift, Kamino), staking, access control, and asset management on Solana",
@@ -61,12 +55,6 @@
       "name": "helius",
       "source": "./skills/helius",
       "description": "Build Solana applications with Helius infrastructure including transaction sending (Sender), asset/NFT queries (DAS API), real-time streaming (WebSockets, LaserStream), event pipelines (webhooks), priority fees, and wallet analysis",
-      "category": "Infrastructure"
-    },
-    {
-      "name": "helius-cli",
-      "source": "./skills/helius-cli",
-      "description": "Command-line tool for AI agents to autonomously sign up for Helius accounts and get API keys without human intervention",
       "category": "Infrastructure"
     },
     {
@@ -80,6 +68,12 @@
       "source": "./skills/helius-phantom",
       "description": "Build frontend Solana applications with Phantom Connect SDK and Helius infrastructure for wallet connection, transaction signing, and secure API proxying",
       "category": "Frontend"
+    },
+    {
+      "name": "jupiter",
+      "source": "./skills/jupiter",
+      "description": "Jupiter APIs — Ultra Swap, Lend, Perps, Trigger, Recurring, Tokens, Price, Portfolio, routing, and production integration patterns",
+      "category": "DeFi"
     },
     {
       "name": "kamino",

--- a/.github/workflows/validate-marketplace.yml
+++ b/.github/workflows/validate-marketplace.yml
@@ -1,0 +1,17 @@
+name: validate marketplace
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: validate plugin paths and SKILL.md
+        run: node scripts/validate-marketplace.js

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Add the marketplace:
 Install skills:
 
 ```
-/plugin install drift
+/plugin install jupiter
 /plugin install helius
 /plugin install meteora
 ```
@@ -33,9 +33,9 @@ Install skills:
 2. Navigate to **Rules & Commands** → **Project Rules** → **Add Rule** → **Remote Rule (GitHub)**
 3. Enter: `https://github.com/sendaifun/skills.git`
 
-Skills are auto-discovered based on context. Ask about Drift perpetuals, Helius RPCs, or Metaplex NFTs and the agent uses the relevant skill automatically.
+Skills are auto-discovered based on context. Ask about Jupiter swaps, Helius RPCs, or Metaplex NFTs and the agent uses the relevant skill automatically.
 
-**Verify:** Ask *"How do I place a perp order on Drift?"* — if working, the agent will reference Drift SDK patterns.
+**Verify:** Ask *"How do I get a quote and swap with Jupiter Ultra?"* — if working, the agent will reference Jupiter API patterns.
 
 ### Any Agent
 
@@ -50,7 +50,6 @@ npx skills add sendaifun/skills
 | Skill | Description |
 |-------|-------------|
 | [jupiter](skills/jupiter/) | Ultra swaps, limit orders, DCA, perpetuals, lending, and token APIs |
-| [drift](skills/drift/) | Perpetuals, spot trading, cross-collateral, and vaults |
 | [glam](skills/glam/) | Tokenized vaults, DeFi integrations (Jupiter, Kamino), staking, asset management |
 | [kamino](skills/kamino/) | Lending, borrowing, liquidity management, leverage trading |
 | [lulo](skills/lulo/) | Lending aggregator across Kamino, Drift, MarginFi, Jupiter |

--- a/scripts/validate-marketplace.js
+++ b/scripts/validate-marketplace.js
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+
+/**
+ * Ensures every marketplace plugin points at a directory that exists and
+ * contains SKILL.md. Prevents broken Claude Code / plugin installs when
+ * entries are added before skill content lands (or vice versa).
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const root = path.join(__dirname, "..");
+const marketplacePath = path.join(root, ".claude-plugin", "marketplace.json");
+
+function main() {
+  let raw;
+  try {
+    raw = fs.readFileSync(marketplacePath, "utf8");
+  } catch (e) {
+    console.error(`Cannot read ${marketplacePath}:`, e.message);
+    process.exit(1);
+  }
+
+  let data;
+  try {
+    data = JSON.parse(raw);
+  } catch (e) {
+    console.error("Invalid JSON in marketplace.json:", e.message);
+    process.exit(1);
+  }
+
+  if (!Array.isArray(data.plugins)) {
+    console.error("marketplace.json: missing or invalid plugins array");
+    process.exit(1);
+  }
+
+  const names = new Set();
+  let failed = false;
+
+  for (const plugin of data.plugins) {
+    if (!plugin || typeof plugin.name !== "string" || !plugin.name) {
+      console.error("Invalid plugin entry (missing name):", plugin);
+      failed = true;
+      continue;
+    }
+    if (names.has(plugin.name)) {
+      console.error(`Duplicate plugin name: ${plugin.name}`);
+      failed = true;
+    }
+    names.add(plugin.name);
+
+    if (typeof plugin.source !== "string" || !plugin.source.startsWith("./")) {
+      console.error(`${plugin.name}: source must be a string starting with ./`);
+      failed = true;
+      continue;
+    }
+
+    const rel = plugin.source.slice(2);
+    const skillDir = path.join(root, rel);
+    const skillMd = path.join(skillDir, "SKILL.md");
+
+    if (!fs.existsSync(skillDir) || !fs.statSync(skillDir).isDirectory()) {
+      console.error(`${plugin.name}: missing directory ${plugin.source}`);
+      failed = true;
+      continue;
+    }
+    if (!fs.existsSync(skillMd)) {
+      console.error(`${plugin.name}: missing ${path.join(plugin.source, "SKILL.md")}`);
+      failed = true;
+    }
+  }
+
+  if (failed) {
+    process.exit(1);
+  }
+
+  console.log(`OK: ${data.plugins.length} marketplace plugins validated`);
+}
+
+main();


### PR DESCRIPTION
## what was wrong

The Claude marketplace file listed **drift** and **helius-cli** with paths under \skills/\, but those folders are not in this repository. Installing those plugins would fail. The readme also told people to \/plugin install drift\ and linked to \skills/drift/\, which does not exist.

At the same time, the **jupiter** skill exists on disk with a full \SKILL.md\ but was missing from the marketplace, so it was not installable through the marketplace even though the readme highlights it.

## what this pr does

- Remove marketplace entries that point at missing skill directories (\drift\, \helius-cli\).
- Register the existing **jupiter** skill in the marketplace (alphabetically with the other plugins).
- Update the readme install examples, verify prompt, and the DeFi table so they match what is actually shipped (drop the broken drift row and links).
- Add \scripts/validate-marketplace.js\ and a GitHub Actions workflow so every plugin path must exist and contain \SKILL.md\ before merge.

---

made by mooncitydev

