### PR TITLE
fix(kamino): correct Kamino Lending mainnet program ID

### DIFF
--- a/skills/kamino/SKILL.md
+++ b/skills/kamino/SKILL.md
@@ -808,7 +808,7 @@ yarn cli print-all-obligation-accounts --rpc <RPC> | jq --stream 'select(.[0][1]
 
 | Program | Address |
 |---------|---------|
-| Kamino Lending | `KLend2g3cP87ber41qQDzWpAFuqP2tCxDqC8S3k7L1U` |
+| Kamino Lending | `KLend2g3cP87fffoy8q1mQqGKjrxjC8boSyAYavgmjD` |
 | Main Market | `7u3HeHxYDLhnCoErrtycNokbQYbWGzLs6JSDqGAv5PfF` |
 | Kamino Liquidity | `KLIQ... (varies)` |
 | Scope Oracle | `ScopE... (varies)` |

--- a/skills/kamino/resources/klend-api-reference.md
+++ b/skills/kamino/resources/klend-api-reference.md
@@ -529,7 +529,7 @@ import {
 } from "@kamino-finance/klend-sdk";
 
 // Program ID
-const PROGRAM_ID = new PublicKey("KLend2g3cP87ber41qQDzWpAFuqP2tCxDqC8S3k7L1U");
+const PROGRAM_ID = new PublicKey("KLend2g3cP87fffoy8q1mQqGKjrxjC8boSyAYavgmjD");
 
 // Main lending market
 const MAIN_MARKET = new PublicKey("7u3HeHxYDLhnCoErrtycNokbQYbWGzLs6JSDqGAv5PfF");

--- a/skills/kamino/resources/program-addresses.md
+++ b/skills/kamino/resources/program-addresses.md
@@ -8,7 +8,7 @@ Reference for all Kamino program and account addresses.
 
 | Program | Address | Description |
 |---------|---------|-------------|
-| Kamino Lending | `KLend2g3cP87ber41qQDzWpAFuqP2tCxDqC8S3k7L1U` | Main lending program |
+| Kamino Lending | `KLend2g3cP87fffoy8q1mQqGKjrxjC8boSyAYavgmjD` | Main lending program |
 | Kamino Liquidity | `6LtLpnUFNByNXLyCoK9wA2MykKAmQNZKBdY8s47dehDc` | Liquidity management program |
 | Scope Oracle | `HFn8GnPADiny6XqUoWE8uRPPxb29ikn4yTuPa9MF2fWJ` | Oracle aggregator |
 
@@ -44,7 +44,7 @@ Reference for all Kamino program and account addresses.
 
 | Program | Address |
 |---------|---------|
-| Kamino Lending | `KLend2g3cP87ber41qQDzWpAFuqP2tCxDqC8S3k7L1U` |
+| Kamino Lending | `KLend2g3cP87fffoy8q1mQqGKjrxjC8boSyAYavgmjD` |
 | Kamino Liquidity | `6LtLpnUFNByNXLyCoK9wA2MykKAmQNZKBdY8s47dehDc` |
 
 ### Test Markets


### PR DESCRIPTION
The Kamino Lending mainnet program ID referenced in the Kamino skill was incorrect. Replaced
`KLend2g3cP87ber41qQDzWpAFuqP2tCxDqC8S3k7L1U` with the correct on-chain address `KLend2g3cP87fffoy8q1mQqGKjrxjC8boSyAYavgmjD`
across all skill files, as per the [official Kamino docs](https://kamino.com/docs/build/resources/program-addresses).
 Closes #46