### PR TITLE
feat: add learn-solana skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -94,6 +94,12 @@
       "category": "DeFi"
     },
     {
+      "name": "learn-solana",
+      "source": "./skills/learn-solana",
+      "description": "Teach Solana, Anchor, SPL Token, PDAs, CPIs, wallets, transactions, validators, programs, and accounts from first principles with examples, exercises, diagrams, tables, and optional single-page HTML explainers",
+      "category": "Research"
+    },
+    {
       "name": "lifi",
       "source": "./skills/lifi",
       "description": "LI.FI cross-chain swaps, bridging, payments, route discovery, and transfer status tracking across Solana, EVM, Bitcoin, and Sui",

--- a/README.md
+++ b/README.md
@@ -122,6 +122,12 @@ npx skills add sendaifun/skills
 |-------|-------------|
 | [pinocchio-development](skills/pinocchio-development/) | Zero-copy framework for high-performance programs (88-95% CU reduction) |
 
+### Research
+
+| Skill | Description |
+|-------|-------------|
+| [learn-solana](skills/learn-solana/) | Beginner-safe Solana lessons, examples, diagrams, exercises, and HTML explainers |
+
 ### AI Agents
 
 | Skill | Description |

--- a/skills/learn-solana/SKILL.md
+++ b/skills/learn-solana/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: learn-solana
+description: Teach any Solana, Anchor, Rust-for-Solana, SPL Token, PDA, account model, CPI, wallet, transaction, validator, or dApp concept from first principles. Use when the user asks to understand, learn, explain, visualize, compare, practice, or turn a Solana topic into a lesson, tutorial, exercise, diagram, table, or finished single-page HTML masterclass explainer.
+license: MIT
+metadata:
+  author: LearnSol
+  version: "1.0.0"
+---
+
+# Learn Solana
+
+This skill turns an agent into a Solana teacher. It is for explaining any Solana topic from first principles, then making the idea concrete with examples, condensed notes, mini diagrams, tables, exercises, and finished temporary HTML explainers when useful.
+
+## Activation
+
+Use this skill when the user asks to:
+
+- explain or simplify a Solana concept
+- learn Solana, Anchor, SPL Token, PDAs, CPIs, wallets, validators, transactions, programs, or accounts
+- compare Solana primitives or developer workflows
+- create lessons, MDX tutorials, quizzes, exercises, or checkpoints
+- make a temporary one-page HTML explainer to teach a Solana idea
+- debug confusion about how a Solana mechanism works
+
+Do not use this skill for generic blockchain explanations unless the answer is explicitly tied back to Solana.
+
+## Required Teaching Contract
+
+Every teaching response must follow this shape unless the user asks for a different format:
+
+1. Start with a one-sentence plain-English definition.
+2. Explain why the concept exists.
+3. Build the mental model with a familiar analogy only if it reduces confusion.
+4. Explain the Solana-specific mechanism.
+5. Show a concrete example with realistic names, accounts, instructions, or code.
+6. Call out common beginner mistakes.
+7. End with a short recap and one practice prompt.
+
+Keep the language simple. Define every term before relying on it. Avoid unexplained jargon, vague metaphors, and hype.
+
+## HTML Explainer Rule
+
+When the user asks for a visual, HTML, page, notes, or artifact, create a finished single-page masterclass explainer by default. Treat it like the page a master teacher would hand to a beginner before a hard topic: complete, carefully sequenced, easy to scan, and concrete.
+
+The output should answer: "If the learner knows nothing about this topic, what is the shortest complete page that makes the idea click without skipping the important details?"
+
+Default artifact style:
+
+- Vercel-like minimalism: white or near-white page, black text, thin borders, restrained gray surfaces.
+- Typography first: strong title, short definition, readable sections, small explanatory diagrams, and compact tables.
+- No decorative gradients, glows, hero art, or dashboard cards.
+- One HTML file with inline CSS, no runtime dependencies, and no external assets.
+- The page should read like a polished technical blog plus condensed notes, not a landing page.
+- Prefer one excellent page over multiple files or a broad tutorial.
+- Use subtle CSS-only motion only when it makes sequence or causality clearer, and include `prefers-reduced-motion`.
+
+Content requirements for finished HTML explainers:
+
+- Never leave placeholder copy.
+- Every section must be topic-specific.
+- Include a tiny glossary before using repeated jargon.
+- Include one "wrong mental model" and the correction.
+- Include at least one mini diagram made from HTML/CSS boxes, arrows, rows, or timelines.
+- Include one concrete Solana example using realistic account, program, instruction, signer, seed, or token names.
+- Include one table that shows relationships, responsibilities, or before/after state.
+- Include three short check-yourself questions and a one-minute recap.
+
+Use compact notes-page explainers for:
+
+- transaction and instruction flow
+- account ownership and data layout
+- PDA derivation and signer behavior
+- CPI call stacks
+- token mint, token account, and associated token account relationships
+- staking, validator, or consensus flows
+- Anchor account validation and instruction lifecycle
+
+For HTML explainer work, first read `references/html-teaching-artifacts.md`. Use `assets/teaching-artifact-template.html` as the base for temporary HTML files.
+
+## Reference Loading
+
+Load only what the task needs:
+
+- `references/topic-framework.md` for the canonical explanation structure and topic-specific teaching angles.
+- `references/html-teaching-artifacts.md` when creating temporary HTML notes pages, diagrams, tables, or teaching files.
+- `references/quality-rubric.md` before finalizing substantial lesson content or any reusable artifact.
+
+## Temporary HTML Artifacts
+
+When creating a temporary HTML artifact:
+
+- Put it in a scratch location such as `tmp/` or another project-appropriate temporary folder.
+- Make it self-contained: one HTML file with inline CSS and minimal inline JavaScript.
+- Default to zero JavaScript.
+- Use semantic sections, readable typography, high contrast, and responsive layout.
+- Prefer precise prose, numbered steps, tiny diagrams, tables, and callouts over large visual systems.
+- Use animation only for subtle CSS sequence/highlight effects, or when the user explicitly asks for more.
+- Include the concept, why it matters, mental model, mechanics, example, pitfalls, check questions, recap, and practice prompt.
+- Tell the user the local file path when finished.
+
+Do not introduce build dependencies for a teaching artifact unless the user asks for a production component.
+
+## Lesson Output Format
+
+For a reusable lesson, produce:
+
+1. Title
+2. Audience level
+3. Learning goals
+4. Prerequisites
+5. First-principles explanation
+6. Solana-specific walkthrough
+7. Example or exercise
+8. Checkpoint questions
+9. Common mistakes
+10. Extension task
+
+For MDX lessons, keep headings scannable, code blocks short, and diagrams close to the concept they explain.
+
+## Quality Gate
+
+Before finalizing, verify:
+
+- The first sentence is understandable to a beginner.
+- Every Solana-specific term is defined before use.
+- The example uses realistic Solana primitives.
+- The explanation separates mental model from implementation detail.
+- Tables or diagrams clarify relationships instead of repeating prose.
+- The learner has one concrete next action.

--- a/skills/learn-solana/assets/teaching-artifact-template.html
+++ b/skills/learn-solana/assets/teaching-artifact-template.html
@@ -1,0 +1,538 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Solana Concept Masterclass</title>
+    <style>
+      :root {
+        color-scheme: light;
+        --bg: #fff;
+        --ink: #09090b;
+        --muted: #666;
+        --soft: #fafafa;
+        --softer: #f4f4f5;
+        --line: #e5e7eb;
+        --accent: #111;
+        --good: #0f766e;
+        --warn: #a16207;
+        --code: #f4f4f5;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        background: var(--bg);
+        color: var(--ink);
+        font-family:
+          Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+          sans-serif;
+        font-size: 16px;
+        line-height: 1.66;
+      }
+
+      .page {
+        width: min(960px, calc(100% - 32px));
+        margin: 0 auto;
+        padding: 52px 0 72px;
+      }
+
+      header {
+        padding-bottom: 30px;
+        border-bottom: 1px solid var(--line);
+      }
+
+      .eyebrow {
+        margin: 0 0 14px;
+        color: var(--muted);
+        font-size: 0.76rem;
+        font-weight: 700;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+      }
+
+      h1 {
+        max-width: 780px;
+        margin: 0;
+        font-size: clamp(2.25rem, 7vw, 4.35rem);
+        line-height: 0.98;
+        letter-spacing: -0.058em;
+      }
+
+      .definition {
+        max-width: 740px;
+        margin: 20px 0 0;
+        color: #2f2f2f;
+        font-size: 1.12rem;
+        line-height: 1.72;
+      }
+
+      .promise {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: 10px;
+        margin-top: 24px;
+      }
+
+      .promise span {
+        border: 1px solid var(--line);
+        border-radius: 12px;
+        background: var(--soft);
+        padding: 10px 12px;
+        color: #3f3f46;
+        font-size: 0.9rem;
+      }
+
+      main {
+        display: grid;
+        gap: 34px;
+        padding-top: 34px;
+      }
+
+      section {
+        scroll-margin-top: 24px;
+      }
+
+      h2 {
+        margin: 0 0 10px;
+        font-size: 1.18rem;
+        line-height: 1.3;
+        letter-spacing: -0.015em;
+      }
+
+      h3 {
+        margin: 0 0 8px;
+        font-size: 0.98rem;
+      }
+
+      p {
+        margin: 0;
+        color: #303034;
+      }
+
+      p + p {
+        margin-top: 12px;
+      }
+
+      ul,
+      ol {
+        margin: 10px 0 0;
+        padding-left: 1.2rem;
+        color: #303034;
+      }
+
+      li + li {
+        margin-top: 7px;
+      }
+
+      code {
+        border: 1px solid var(--line);
+        border-radius: 6px;
+        background: var(--code);
+        padding: 0.12rem 0.35rem;
+        font-family:
+          "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+        font-size: 0.92em;
+      }
+
+      .callout {
+        border: 1px solid var(--line);
+        border-radius: 12px;
+        background: var(--soft);
+        padding: 16px;
+      }
+
+      .callout strong {
+        color: var(--ink);
+      }
+
+      .grid-two {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 12px;
+      }
+
+      .mini-card {
+        border: 1px solid var(--line);
+        border-radius: 12px;
+        background: #fff;
+        padding: 14px;
+      }
+
+      .mini-card p {
+        font-size: 0.94rem;
+      }
+
+      .steps {
+        display: grid;
+        gap: 10px;
+        counter-reset: step;
+      }
+
+      .step {
+        display: grid;
+        grid-template-columns: auto 1fr;
+        gap: 12px;
+        align-items: start;
+        border: 1px solid var(--line);
+        border-radius: 12px;
+        padding: 14px;
+        background: #fff;
+      }
+
+      .step::before {
+        counter-increment: step;
+        content: counter(step);
+        display: grid;
+        width: 28px;
+        height: 28px;
+        place-items: center;
+        border-radius: 999px;
+        background: var(--ink);
+        color: #fff;
+        font-size: 0.84rem;
+        font-weight: 700;
+      }
+
+      .diagram {
+        border: 1px solid var(--line);
+        border-radius: 14px;
+        background: var(--soft);
+        padding: 16px;
+      }
+
+      .diagram-row {
+        display: grid;
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+        gap: 10px;
+        align-items: stretch;
+      }
+
+      .diagram-box {
+        min-height: 88px;
+        border: 1px solid var(--line);
+        border-radius: 12px;
+        background: #fff;
+        padding: 12px;
+        position: relative;
+      }
+
+      .diagram-box:not(:last-child)::after {
+        content: "->";
+        position: absolute;
+        top: 50%;
+        right: -18px;
+        transform: translateY(-50%);
+        color: var(--muted);
+        font-family:
+          "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+        font-size: 0.85rem;
+      }
+
+      .diagram-box span {
+        display: block;
+        color: var(--muted);
+        font-size: 0.78rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+      }
+
+      .diagram-box strong {
+        display: block;
+        margin-top: 5px;
+        line-height: 1.25;
+      }
+
+      .diagram-box small {
+        display: block;
+        margin-top: 6px;
+        color: var(--muted);
+        line-height: 1.45;
+      }
+
+      .diagram-box.result {
+        border-color: #c7d2fe;
+        background: #f8fafc;
+      }
+
+      @media (prefers-reduced-motion: no-preference) {
+        .diagram-box {
+          animation: rise 480ms ease-out both;
+        }
+
+        .diagram-box:nth-child(2) {
+          animation-delay: 90ms;
+        }
+
+        .diagram-box:nth-child(3) {
+          animation-delay: 180ms;
+        }
+
+        .diagram-box:nth-child(4) {
+          animation-delay: 270ms;
+        }
+      }
+
+      @keyframes rise {
+        from {
+          opacity: 0;
+          transform: translateY(6px);
+        }
+        to {
+          opacity: 1;
+          transform: translateY(0);
+        }
+      }
+
+      table {
+        width: 100%;
+        margin-top: 12px;
+        border-collapse: collapse;
+        overflow: hidden;
+        border: 1px solid var(--line);
+        border-radius: 12px;
+        font-size: 0.94rem;
+      }
+
+      th,
+      td {
+        padding: 12px;
+        border-bottom: 1px solid var(--line);
+        text-align: left;
+        vertical-align: top;
+      }
+
+      th {
+        background: var(--soft);
+        color: var(--muted);
+        font-size: 0.76rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+
+      tr:last-child td {
+        border-bottom: 0;
+      }
+
+      .mistakes {
+        display: grid;
+        gap: 10px;
+      }
+
+      .mistake {
+        border-left: 3px solid var(--warn);
+        padding: 10px 0 10px 12px;
+        background: linear-gradient(90deg, #fff7ed, transparent);
+      }
+
+      .checks {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: 10px;
+      }
+
+      .check {
+        border: 1px solid var(--line);
+        border-radius: 12px;
+        padding: 14px;
+        background: var(--soft);
+      }
+
+      .recap {
+        border-top: 1px solid var(--line);
+        padding-top: 24px;
+      }
+
+      @media (max-width: 760px) {
+        .page {
+          width: min(100% - 24px, 960px);
+          padding: 36px 0 48px;
+        }
+
+        .promise,
+        .grid-two,
+        .diagram-row,
+        .checks {
+          grid-template-columns: 1fr;
+        }
+
+        .diagram-box:not(:last-child)::after {
+          content: "";
+        }
+
+        h1 {
+          font-size: clamp(2rem, 12vw, 3.15rem);
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="page">
+      <header>
+        <p class="eyebrow">Solana masterclass notes</p>
+        <h1>Replace with the concept name</h1>
+        <p class="definition">
+          Start with one plain-English definition that works for someone who has never seen
+          the concept before.
+        </p>
+        <div class="promise" aria-label="What this page teaches">
+          <span>What problem this solves</span>
+          <span>How Solana implements it</span>
+          <span>How to avoid the common traps</span>
+        </div>
+      </header>
+
+      <main>
+        <section>
+          <h2>Start here</h2>
+          <p>
+            Define the concept without jargon. State what the learner should understand by
+            the end of this page.
+          </p>
+        </section>
+
+        <section>
+          <h2>Why it exists</h2>
+          <p>
+            Explain the real Solana problem this concept solves. Avoid generic blockchain
+            framing unless it directly explains the Solana mechanism.
+          </p>
+        </section>
+
+        <section class="callout">
+          <h2>Mental model</h2>
+          <p>
+            Use one analogy that helps the learner reason about the concept, then explain
+            where the analogy stops matching the implementation.
+          </p>
+        </section>
+
+        <section>
+          <h2>Vocabulary you need</h2>
+          <div class="grid-two">
+            <div class="mini-card">
+              <h3><code>term_one</code></h3>
+              <p>Define this term in beginner language.</p>
+            </div>
+            <div class="mini-card">
+              <h3><code>term_two</code></h3>
+              <p>Define this term before using it repeatedly.</p>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <h2>How Solana does it</h2>
+          <div class="steps">
+            <div class="step">
+              <p>Step one: identify the signer, account, program, or instruction involved.</p>
+            </div>
+            <div class="step">
+              <p>Step two: describe what Solana reads, writes, derives, or verifies.</p>
+            </div>
+            <div class="step">
+              <p>Step three: show the resulting state or capability.</p>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <h2>Mini diagram</h2>
+          <div class="diagram" aria-label="Concept flow diagram">
+            <div class="diagram-row">
+              <div class="diagram-box">
+                <span>Input</span>
+                <strong>Actor or seed</strong>
+                <small>Replace with the first ingredient.</small>
+              </div>
+              <div class="diagram-box">
+                <span>Mechanism</span>
+                <strong>Program rule</strong>
+                <small>Replace with what Solana verifies.</small>
+              </div>
+              <div class="diagram-box">
+                <span>State</span>
+                <strong>Account change</strong>
+                <small>Replace with what changes on-chain.</small>
+              </div>
+              <div class="diagram-box result">
+                <span>Result</span>
+                <strong>Learner takeaway</strong>
+                <small>Replace with the final capability.</small>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <h2>Concrete example</h2>
+          <p>
+            Use realistic Solana names here: a wallet, a program id, an instruction, account
+            names, seeds, authorities, or token accounts. Explain why each piece is present.
+          </p>
+        </section>
+
+        <section>
+          <h2>Tiny table</h2>
+          <table>
+            <thead>
+              <tr>
+                <th>Thing</th>
+                <th>What it means</th>
+                <th>Beginner translation</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><code>account</code></td>
+                <td>Persistent on-chain storage owned by a program.</td>
+                <td>A labeled storage box.</td>
+              </tr>
+              <tr>
+                <td><code>program</code></td>
+                <td>Executable logic that can change accounts it owns.</td>
+                <td>The rules for changing boxes.</td>
+              </tr>
+            </tbody>
+          </table>
+        </section>
+
+        <section>
+          <h2>Common mistakes</h2>
+          <div class="mistakes">
+            <div class="mistake">
+              <strong>Wrong mental model:</strong> replace with the beginner misconception.
+              <br />
+              <strong>Correction:</strong> replace with the precise Solana model.
+            </div>
+            <div class="mistake">
+              <strong>Wrong shortcut:</strong> replace with another common mistake.
+              <br />
+              <strong>Correction:</strong> replace with what to remember instead.
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <h2>Check yourself</h2>
+          <div class="checks">
+            <div class="check">Question 1 that tests the definition.</div>
+            <div class="check">Question 2 that tests the mechanism.</div>
+            <div class="check">Question 3 that tests the common mistake.</div>
+          </div>
+        </section>
+
+        <section class="recap">
+          <h2>One-minute recap</h2>
+          <p>
+            Compress the whole concept into two or three sentences, then give one small
+            exercise that forces the learner to apply it.
+          </p>
+        </section>
+      </main>
+    </div>
+  </body>
+</html>

--- a/skills/learn-solana/references/html-teaching-artifacts.md
+++ b/skills/learn-solana/references/html-teaching-artifacts.md
@@ -1,0 +1,162 @@
+# HTML Teaching Artifacts
+
+Use this reference when creating temporary HTML explainers.
+
+## Artifact Goals
+
+An HTML artifact should be a finished one-page masterclass explainer. It should feel like a polished Vercel-style technical article plus condensed teacher notes: calm typography, strong structure, white space, thin borders, tiny diagrams, and no visual noise.
+
+The default output is not a diagram dashboard. It is a complete beginner-safe page for someone who does not know the topic at all.
+
+Prioritize:
+
+- one-sentence first-principles definition
+- why the concept exists
+- simple mental model
+- wrong mental model and correction
+- small glossary
+- compact Solana-specific mechanics
+- one realistic example
+- mini HTML/CSS diagram
+- tiny tables for relationships or before/after state
+- common mistakes
+- check-yourself questions
+- one practice prompt
+
+Avoid:
+
+- decorative illustrations
+- dashboard-style cards
+- large visual systems when text would teach better
+- complex frameworks
+- dependency installation
+- gradients, glows, shadows, bokeh, and stock decorative backgrounds
+- animation unless the user explicitly asks for it
+- placeholder copy
+- generic blockchain filler that is not Solana-specific
+
+## Required Structure
+
+Use one self-contained HTML file:
+
+- `<header>` for the concept name, learner promise, and one-sentence definition
+- `<main>` for the notes content
+- `<section>` blocks for problem, mental model, glossary, mechanics, diagram, example, mistakes, checks, and recap
+- inline `<style>` for CSS
+- no JavaScript unless the user explicitly asks for interactivity
+
+## Required Page Sections
+
+Use this sequence unless the user requests a different teaching format:
+
+1. `Start here` - one plain-English definition and what the learner will understand by the end.
+2. `Why it exists` - the problem this concept solves.
+3. `Mental model` - a simple model, clearly marked as a simplification.
+4. `Vocabulary` - tiny glossary of terms used later.
+5. `How Solana does it` - concrete mechanics and vocabulary.
+6. `Mini diagram` - small HTML/CSS diagram with labels.
+7. `Concrete example` - realistic account/program/instruction example.
+8. `Tiny table` - comparison, before/after state, or actor responsibility.
+9. `Common mistakes` - short mistake/correction pairs.
+10. `Check yourself` - three short questions.
+11. `One-minute recap` - compressed summary and one exercise.
+
+## Minimal Visual Patterns
+
+Use these as compact teaching aids inside the notes page. Diagrams should clarify, not decorate.
+
+### Relationship Table
+
+Use for account ownership, token roles, authority, or CPI privileges.
+
+Columns should usually be:
+
+- thing
+- what it means
+- who controls it
+- beginner translation
+
+### Before/After Table
+
+Use when state changes.
+
+Columns should usually be:
+
+- step
+- account or actor
+- what changed
+
+### Recipe List
+
+Use for PDA seeds, transaction construction, or Anchor validation.
+
+Keep it as an ordered list or a two-column table. Avoid giant arrows unless the user asks.
+
+### Mini Diagram
+
+Use CSS boxes and arrows for the one diagram. Pick the pattern that matches the topic:
+
+- PDA: seed chips -> program id -> bump -> derived address
+- transaction: signer -> transaction -> instruction -> program -> account changes
+- CPI: caller program -> invoked program -> returned result
+- SPL Token: mint -> token account -> owner authority
+- Anchor: account validation -> instruction logic -> state update
+
+Rules:
+
+- Keep it within one section.
+- Use labels inside the diagram.
+- Avoid canvas, SVG, and external images.
+- Use subtle CSS-only motion only if it explains order.
+- Respect `prefers-reduced-motion`.
+
+## Style Rules
+
+Use a restrained system:
+
+- background: `#fff`
+- text: near black
+- muted text: neutral gray
+- accent: one restrained blue or black
+- borders: `1px solid #e5e7eb`
+- radius: 12px or less
+- no heavy shadows
+
+Typography:
+
+- system sans for prose
+- system mono for code and addresses
+- body text around 16px
+- readable line-height
+- max content width around 920px
+- no huge hero typography
+
+Content density:
+
+- The page may be detailed, but every paragraph should earn its place.
+- Prefer short paragraphs and structured lists.
+- Use code snippets sparingly and explain every snippet.
+- Do not exceed what a focused beginner can read in 8-10 minutes.
+
+## File Naming
+
+Use descriptive temporary names:
+
+- `tmp/pda-explainer.html`
+- `tmp/cpi-flow.html`
+- `tmp/spl-token-accounts.html`
+- `tmp/transaction-lifecycle.html`
+
+## Completion Checklist
+
+- The artifact opens directly in a browser.
+- It has no external runtime dependencies.
+- The main idea is understandable from the first screen.
+- The page can teach someone who has never seen the topic.
+- It is concise enough to scan quickly and complete enough to teach the essentials.
+- It contains a concrete Solana example.
+- It contains a mini diagram.
+- It contains check-yourself questions.
+- Tables clarify relationships instead of decorating the page.
+- No placeholders remain.
+- The file path is reported to the user.

--- a/skills/learn-solana/references/quality-rubric.md
+++ b/skills/learn-solana/references/quality-rubric.md
@@ -1,0 +1,45 @@
+# Quality Rubric
+
+Use this before finalizing substantial Solana teaching output.
+
+## Accuracy
+
+- Does the answer separate accounts, programs, instructions, and transactions correctly?
+- Does it avoid saying that programs own private keys?
+- Does it distinguish wallet authority from program ownership?
+- Does it explain that transaction execution is atomic when relevant?
+- Does it avoid implying that PDAs are random addresses?
+- Does it distinguish token mint accounts from token accounts?
+
+## Beginner Clarity
+
+- Does the opening sentence work for someone new to Solana?
+- Are terms defined before they are used?
+- Are there fewer than three new terms introduced at once?
+- Is the analogy clearly marked as a mental model rather than exact implementation?
+
+## Teaching Value
+
+- Does the response show before and after state when state changes matter?
+- Does the example use realistic Solana primitives?
+- Does the learner get a concrete exercise or next step?
+- Do tables and diagrams reduce cognitive load?
+- Does the explanation include a wrong mental model and correction?
+- Does the learner get check-yourself questions?
+
+## Artifact Quality
+
+- Is the temporary HTML self-contained?
+- Does it look like a polished technical blog or masterclass notes page instead of a landing page?
+- Is the first screen enough to orient a beginner?
+- Are sections ordered from first principles to concrete Solana mechanics?
+- Is there at least one compact diagram built from HTML/CSS?
+- Are tables compact and useful?
+- Does it avoid decorative gradients, glows, and unnecessary animation?
+- Is the layout usable on mobile and desktop?
+- Are colors high contrast and not purely decorative?
+- Are there no placeholders or generic filler sections?
+
+## Final Pass
+
+If any answer to the above is "no", revise before finalizing.

--- a/skills/learn-solana/references/topic-framework.md
+++ b/skills/learn-solana/references/topic-framework.md
@@ -1,0 +1,122 @@
+# Topic Framework
+
+Use this reference to choose the strongest teaching angle for a Solana topic.
+
+## Universal Explanation Flow
+
+1. Name the concept in plain English.
+2. Explain the problem it solves.
+3. Identify the actors involved.
+4. Show the state before the operation.
+5. Walk through the operation step by step.
+6. Show the state after the operation.
+7. Connect the mental model to Solana implementation details.
+8. Give one exercise that makes the learner manipulate the idea.
+
+## Common Solana Topics
+
+### Accounts
+
+Teach accounts as persistent storage boxes on-chain. Emphasize:
+
+- accounts hold data and lamports
+- every account has an owner program
+- only the owner program can change the account data
+- users sign transactions, programs do not hold private keys
+
+Best visuals:
+
+- account box table
+- owner arrows
+- before/after data changes
+
+### Transactions and Instructions
+
+Teach a transaction as a signed envelope containing one or more instructions. Emphasize:
+
+- the transaction is signed by required signers
+- instructions name the program to run
+- accounts are passed into instructions
+- execution is atomic
+
+Best visuals:
+
+- envelope diagram
+- ordered instruction timeline
+- account read/write table
+
+### Programs
+
+Teach programs as stateless executable code. Emphasize:
+
+- programs live in executable accounts
+- program state is stored in separate accounts
+- instructions are entrypoints into program logic
+- upgrades depend on the program's upgrade authority
+
+Best visuals:
+
+- program-to-account relationship map
+- instruction dispatch table
+
+### PDAs
+
+Teach PDAs as deterministic addresses controlled by a program, not by a private key. Emphasize:
+
+- derived from seeds plus program id
+- cannot be signed by a user private key
+- the owning program can sign for a PDA during CPI with the correct seeds
+- seeds are part of the app's address design
+
+Best visuals:
+
+- seed recipe diagram
+- derived address output
+- signer comparison table
+
+### CPI
+
+Teach CPI as one Solana program calling another program during one instruction. Emphasize:
+
+- the outer program invokes another program
+- accounts must be passed through correctly
+- signer privileges can be forwarded
+- PDA signing requires seeds
+
+Best visuals:
+
+- call stack
+- actor lanes
+- privilege forwarding table
+
+### SPL Token
+
+Teach SPL Token as a standard program for mints and balances. Emphasize:
+
+- mint account defines the token
+- token account holds a user's balance for one mint
+- associated token account is the conventional token account for a wallet and mint
+- mint authority creates supply
+- owner authority controls a token account
+
+Best visuals:
+
+- mint-to-token-account relationship map
+- authority table
+- transfer state change
+
+### Anchor
+
+Teach Anchor as a framework that reduces Solana boilerplate. Emphasize:
+
+- account validation happens before instruction logic
+- constraints encode safety assumptions
+- account structs describe required accounts
+- errors should explain violated assumptions
+
+Best visuals:
+
+- instruction lifecycle
+- account validation checklist
+- Anchor macro to raw Solana concept mapping
+


### PR DESCRIPTION
 ## Summary

  Adds the `learn-solana` skill for teaching Solana concepts from first
  principles with examples, exercises, diagrams, tables, and optional single-
  page HTML explainers.

  ## Changes

  - Added `skills/learn-solana`
  - Added supporting references and HTML teaching artifact template
  - Added marketplace entry
  - Added README listing under Research

Official LearnSol project: https://www.learnsol.site/