### PR TITLE
Add Solana launch readiness skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -240,7 +240,7 @@
     {
       "name": "solana-launch-readiness",
       "source": "./skills/solana-launch-readiness",
-      "description": "Evidence-backed go/no-go launch readiness for Solana apps and AI-agent workflows across wallet UX, RPC, transactions, public addresses, operations, support, and Solana Agent Kit write-action gates.",
+      "description": "Solana release gate for AI agents: evidence-backed go/no-go readiness across wallet UX, RPC, transactions, public addresses, operations, support, and Solana Agent Kit write-action gates.",
       "category": "DevOps"
     },
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -238,6 +238,12 @@
       "category": "Client Development"
     },
     {
+      "name": "solana-launch-readiness",
+      "source": "./skills/solana-launch-readiness",
+      "description": "Evidence-backed go/no-go launch readiness for Solana apps and AI-agent workflows across wallet UX, RPC, transactions, public addresses, operations, support, and Solana Agent Kit write-action gates.",
+      "category": "DevOps"
+    },
+    {
       "name": "svm",
       "source": "./skills/svm",
       "description": "Explore Solana's architecture and protocol internals including the SVM execution engine, account model, consensus, transactions, and validator economics",

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ npx skills add sendaifun/skills
 
 | Skill | Description |
 |-------|-------------|
+| [solana-launch-readiness](skills/solana-launch-readiness/) | Go/no-go launch readiness for Solana apps and AI-agent workflows |
 | [surfpool](skills/surfpool/) | Development environment with mainnet forking, cheatcodes |
 
 ## Ideas

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ npx skills add sendaifun/skills
 
 | Skill | Description |
 |-------|-------------|
-| [solana-launch-readiness](skills/solana-launch-readiness/) | Go/no-go launch readiness for Solana apps and AI-agent workflows |
+| [solana-launch-readiness](skills/solana-launch-readiness/) | Solana release gate for AI-agent go/no-go launch readiness |
 | [surfpool](skills/surfpool/) | Development environment with mainnet forking, cheatcodes |
 
 ## Ideas

--- a/skills/solana-launch-readiness/SKILL.md
+++ b/skills/solana-launch-readiness/SKILL.md
@@ -1,11 +1,19 @@
 ---
 name: solana-launch-readiness
-description: Review Solana applications before launch and produce a practical launch-readiness report. Use when Codex or another AI coding agent needs to inspect a Solana dApp, wallet flow, token launch, program integration, demo URL, or repository before mainnet/public release, especially for wallet UX, RPC/network configuration, token metadata, transaction safety, monitoring, documentation, support, incident response, release gates, and go/no-go decisions.
+description: Review Solana applications before launch and produce an evidence-backed go/no-go report. Use when Codex or another AI coding agent needs a Solana-specific release gate for a dApp, wallet flow, token launch, program integration, demo URL, or repository before mainnet/public release, especially for wallet UX, RPC/network configuration, token metadata, transaction safety, Solana Agent Kit write-action gates, monitoring, support, incident response, and launch ownership.
 ---
 
 # Solana Launch Gate
 
 Use this skill as an evidence-backed launch gate for a Solana app or AI-agent workflow before public or mainnet launch. Focus on blockers and concrete next actions, not broad advice.
+
+## Compatibility Contract
+
+- Use progressive loading: start from this file, then load only the references needed for the review.
+- Keep the review Solana-specific; do not turn it into a generic launch or startup checklist.
+- Treat scripts as optional evidence helpers. The final severity still requires manual verification.
+- Avoid live write actions by default. Do not sign, submit, simulate with private keys, mutate accounts, deploy, or run destructive commands unless the user explicitly authorizes that separate action.
+- Produce a stable launch-owner report with `GO`, `GO WITH WARNINGS`, or `NO-GO UNTIL FIXED`.
 
 ## Workflow
 

--- a/skills/solana-launch-readiness/SKILL.md
+++ b/skills/solana-launch-readiness/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: solana-launch-readiness
+description: Review Solana applications before launch and produce a practical launch-readiness report. Use when Codex or another AI coding agent needs to inspect a Solana dApp, wallet flow, token launch, program integration, demo URL, or repository before mainnet/public release, especially for wallet UX, RPC/network configuration, token metadata, transaction safety, monitoring, documentation, support, incident response, release gates, and go/no-go decisions.
+---
+
+# Solana Launch Gate
+
+Use this skill as an evidence-backed launch gate for a Solana app or AI-agent workflow before public or mainnet launch. Focus on blockers and concrete next actions, not broad advice.
+
+## Workflow
+
+1. Identify launch scope:
+   - app or repo name
+   - target network: devnet, testnet, mainnet-beta, localnet, or unknown
+   - launch type: private beta, public beta, mainnet launch, token launch, campaign, or migration
+   - expected users, wallets, tokens, programs, and critical flows
+2. Inspect available artifacts:
+   - repository files, docs, README, env examples, tests, CI, deployment config
+   - frontend wallet flow, transaction creation, signing, confirmation, error states
+   - API/RPC clients, rate limits, retries, fallbacks, and network selection
+   - token metadata, mint/program IDs, explorer links, and verified addresses
+   - monitoring, analytics, support, runbooks, changelogs, and status pages
+3. Load references as needed:
+   - Read `references/checklist.md` before scoring readiness.
+   - Read `references/evidence.md` when collecting proof from a repo or live app.
+   - Read `references/scoring-rubric.md` before assigning recommendation severity.
+   - Read `references/use-cases.md` when classifying launch context or writing owner-facing summaries.
+   - Read `references/solana-agent-kit.md` when the project uses Solana Agent Kit, MCP, LangChain/Vercel AI tools, autonomous Solana agents, or AI-controlled write actions.
+   - Read `references/report-template.md` before writing the final report.
+4. If this skill's scripts are available, run the lightweight scanner for first-pass evidence. In an installed skill, scripts live at `scripts/` beside this `SKILL.md`; in the source package, scripts live at the repository root `scripts/`.
+
+   ```bash
+   python3 scripts/scan_repo.py <repo-path> --pretty
+   ```
+
+   Treat scanner results as signals, not final findings. Verify impact manually. The scanner applies best-effort redaction and skips private `.env*` files unless explicitly asked with `--include-private-env`; avoid scanning private env files unless necessary.
+5. For transaction-heavy apps, run the offline transaction pattern scanner:
+
+   ```bash
+   python3 scripts/tx_pattern_scan.py <repo-path> --pretty
+   ```
+
+   Use missing or risky transaction patterns to guide manual review of blockhash expiry, retries, priority fees, compute budget, versioned transactions, ALTs, preflight, and confirmation behavior.
+6. When the team provides public launch addresses and explicitly allows network access, optionally run the read-only RPC probe:
+
+   ```bash
+   node scripts/rpc_readiness_probe.mjs launch-config.json --timeout-ms 8000
+   ```
+
+   This only calls JSON-RPC read methods such as `getSlot`, `getLatestBlockhash`, and `getAccountInfo`; it does not sign or submit transactions.
+7. Produce a report that separates:
+   - launch blockers
+   - warnings
+   - nice-to-haves
+   - validated strengths
+   - unknowns requiring owner confirmation
+8. Recommend one of:
+   - `GO`
+   - `GO WITH WARNINGS`
+   - `NO-GO UNTIL FIXED`
+
+## Review Rules
+
+- Prefer concrete file paths, commands, screenshots, logs, URLs, or code references over generic observations.
+- Do not claim a smart contract is secure unless a real audit or formal analysis was performed.
+- Do not perform live transactions, wallet signatures, mainnet testing, or destructive actions unless the user explicitly authorizes them.
+- Treat private keys, seed phrases, RPC keys, wallet addresses tied to private identity, KYC data, and payment details as sensitive.
+- Never print secret values from environment files, CI logs, launch configs, or scanner output. Redact values and cite only variable names, file paths, and line numbers.
+- If source code is unavailable, say so and produce an external-readiness review from visible docs and UI only.
+- If the app uses a non-Solana chain in addition to Solana, keep the Solana findings separate.
+- If a launch area cannot be verified, list it under unknowns instead of guessing.
+- If using `scripts/scan_repo.py`, include a short scanner summary and note which signals were manually verified.
+- If using `scripts/tx_pattern_scan.py` or `scripts/rpc_readiness_probe.mjs`, include the generated evidence under scanner/tooling summary and keep unverifiable chain authority or metadata questions under unknowns.
+
+## Output Standard
+
+Every final report must include:
+
+- scope and evidence sources
+- scanner summary when applicable
+- category scorecard
+- one-line launch recommendation
+- launch blockers table
+- warnings table
+- verified strengths
+- critical unknowns
+- prioritized next actions
+- owner-facing summary
+
+Use concise, engineering-friendly language. Include enough detail for the team to fix issues without re-running the whole review.

--- a/skills/solana-launch-readiness/references/checklist.md
+++ b/skills/solana-launch-readiness/references/checklist.md
@@ -1,0 +1,74 @@
+# Launch Readiness Checklist
+
+Use this checklist to score a Solana app before launch. Mark each item as `pass`, `warning`, `blocker`, or `unknown`.
+
+## Wallet UX
+
+- Wallet connect flow works for the target wallets and target network.
+- Unsupported wallets or networks produce clear user-facing errors.
+- Users can recover from rejected signatures without refreshing the app.
+- Transaction simulation failures are surfaced with useful next steps.
+- Pending, confirmed, failed, expired, and retried transaction states are visible.
+- The app does not ask users to sign ambiguous messages or transactions.
+
+## Network And RPC
+
+- Target network is explicit in UI, docs, and environment config.
+- Devnet/testnet/mainnet-beta values are not mixed in production config.
+- RPC endpoints are configurable without code changes.
+- RPC keys are not committed to public source.
+- Rate limits, retries, timeout behavior, and fallback RPCs are documented or implemented.
+- Confirmation commitment levels are intentional and consistent with the product risk.
+
+## Programs, Mints, And Metadata
+
+- Program IDs, mint addresses, token accounts, and market IDs are documented.
+- Public addresses are copyable and linked to the correct explorer/network.
+- Token metadata matches the launch narrative and expected decimals/symbols.
+- Upgrade authority, freeze authority, mint authority, or governance status is disclosed when relevant.
+- Program accounts exist on the target cluster and executable status is verified when relevant.
+- SPL Token vs Token-2022 assumptions are explicit, including extensions, transfer hooks, fees, or confidential transfer behavior.
+- Metaplex metadata URI, name, symbol, image, and seller fee basis points are verified for NFT or compressed NFT launches.
+- Seed data, allowlists, and config accounts are versioned or reproducible.
+
+## Transactions And Safety
+
+- Critical flows have tests or scripted dry-runs.
+- Transaction construction preserves required existing signatures.
+- Multi-transaction flows define ordering and retry behavior.
+- Duplicate submissions and idempotency are handled where relevant.
+- User balances, rent, fees, slippage, and account creation requirements are explained before signing.
+- Associated token account creation, rent funding, and insufficient SOL/token balances have visible recovery paths.
+- Latest blockhash and `lastValidBlockHeight` are used or intentionally replaced by another expiry strategy.
+- Priority fee and compute budget behavior is intentional for expected launch congestion.
+- Versioned transactions and address lookup tables are used or intentionally avoided based on account list size and wallet support.
+- Preflight, simulation logs, `maxRetries`, and commitment levels are intentional and documented for critical flows.
+- Failure modes do not leave users without a recovery path.
+
+## Docs And Developer Experience
+
+- README explains setup, env vars, target network, and launch mode.
+- `.env.example` or equivalent exists and avoids real secrets.
+- API docs or SDK examples match current code.
+- Known limitations are documented.
+- New users can complete the main happy path from docs alone.
+- Error glossary or troubleshooting guide covers common Solana failures.
+
+## Observability And Operations
+
+- Frontend and backend errors are logged with privacy-safe metadata.
+- Transaction signatures and user-facing failures can be correlated.
+- There is monitoring for RPC errors, failed transactions, failed indexing, and degraded APIs.
+- Support can triage a failed transaction from signature, wallet prefix, flow name, sanitized error code, and timestamp.
+- There is a status page, support channel, or incident communication plan.
+- Rollback or pause procedures are documented for critical releases.
+- Owners are assigned for launch day response.
+
+## Release Gates
+
+- CI passes and includes relevant tests, linting, or type checks.
+- Build and deployment commands are documented.
+- Production environment and release commit/tag are identifiable.
+- Analytics or event tracking confirms core funnel steps.
+- Legal/risk disclaimers are reviewed where the app involves tokens, trading, rewards, or financial claims.
+- A go/no-go checklist exists with named owners and deadlines.

--- a/skills/solana-launch-readiness/references/evidence.md
+++ b/skills/solana-launch-readiness/references/evidence.md
@@ -1,0 +1,106 @@
+# Evidence Collection Guide
+
+Collect evidence before assigning severity. Prefer reproducible proof.
+
+## Repository Evidence
+
+Use fast local search first:
+
+```bash
+rg -n "mainnet|devnet|testnet|localnet|cluster|RPC|HELIUS|QUICKNODE|TRITON|ANCHOR|PROGRAM_ID|MINT|wallet|signTransaction|sendTransaction|confirmTransaction|skipPreflight|commitment|slippage|retry|timeout|webhook|status" .
+rg --files | rg 'README|CHANGELOG|docs|\\.env|env.example|package.json|Anchor.toml|Cargo.toml|next.config|vite.config|vercel|docker|ci|workflow'
+```
+
+Use bundled offline scripts when available:
+
+```bash
+python3 scripts/scan_repo.py <repo-path> --pretty
+python3 scripts/tx_pattern_scan.py <repo-path> --pretty
+```
+
+Look for:
+
+- committed secrets or production RPC keys
+- missing env examples
+- hard-coded devnet/mainnet values
+- stale program IDs or mint addresses
+- disabled preflight or unclear commitment settings
+- missing transaction confirmation handling
+- absent tests for critical launch flows
+- missing latest blockhash, lastValidBlockHeight, priority fee, compute budget, retry, and preflight intent
+- missing ATA/rent UX for token flows
+- Solana Agent Kit, MCP, LangChain, Vercel AI SDK, or autonomous tool registrations that can perform write actions
+
+## Read-Only Chain And RPC Evidence
+
+Only run network probes when the user provides public addresses and allows network access. Use read-only RPC calls:
+
+```bash
+node scripts/rpc_readiness_probe.mjs launch-config.json --timeout-ms 8000
+```
+
+Check:
+
+- RPC endpoint health, latency, latest slot, and latest blockhash
+- program account existence, executable flag, owner, and lamports
+- mint account existence and owner
+- explorer links match the target cluster and public docs
+- authority status is documented: upgrade, freeze, mint, governance, or multisig
+
+Keep authority and metadata questions under unknowns if the probe cannot verify them.
+
+## Solana Agent Kit Evidence
+
+If Solana Agent Kit or AI-controlled tools are present, also search:
+
+```bash
+rg -n "SolanaAgentKit|createSolanaTools|Keypair|fromSecretKey|MCP|tool\\(|generateText|streamText|LangChain|transfer|swap|stake|mint|burn|closeAccount|setAuthority" .
+```
+
+Check:
+
+- wallet/private-key custody and whether keys can reach browser code
+- read-only vs write-capable tool separation
+- explicit human confirmation gates for mainnet write actions
+- autonomous spending, retry, timeout, and rate limits
+- action logs for signature, cluster, wallet prefix, tool name, sanitized error code, and timestamp
+
+## Live App Evidence
+
+If browser access is safe and allowed:
+
+- capture URL, timestamp, network, wallet state, and browser console errors
+- inspect visible network labels and explorer links
+- test read-only navigation before any wallet action
+- do not sign, connect a real wallet, or submit transactions without explicit approval
+- record exact user-facing error text
+
+## Documentation Evidence
+
+Check:
+
+- setup instructions
+- target network and env variables
+- launch addresses and explorer links
+- support path and incident contact
+- troubleshooting and known limitations
+- warnings for financial, trading, or token-risk behavior
+- launch config or runbook with owners, target cluster, release commit, RPC providers, pause/rollback commands, support channel, program IDs, and mint IDs
+
+## Severity Guide
+
+`blocker`:
+
+- likely causes failed launch, user fund risk, broken onboarding, wrong network use, exposed secrets, or unrecoverable critical flow failure
+
+`warning`:
+
+- materially hurts reliability, support load, trust, or conversion but has a workaround
+
+`nice-to-have`:
+
+- improves quality or polish but should not block launch
+
+`unknown`:
+
+- cannot be verified from available artifacts and needs owner confirmation

--- a/skills/solana-launch-readiness/references/report-template.md
+++ b/skills/solana-launch-readiness/references/report-template.md
@@ -1,0 +1,85 @@
+# Launch Readiness Report Template
+
+Use this structure for the final report.
+
+```markdown
+# Solana Launch Readiness Report
+
+## Scope
+
+- App / repo:
+- Launch type:
+- Target network:
+- Review date:
+- Evidence sources:
+
+## Scanner Summary
+
+Include only when `scripts/scan_repo.py` or another automated pass was used. Summarize files scanned, finding counts, manually verified signals, and false positives.
+
+## Category Scorecard
+
+| Category | Score 0-3 | Rationale |
+| --- | ---: | --- |
+| Wallet UX |  |  |
+| Network/RPC |  |  |
+| Addresses/Metadata |  |  |
+| Transaction Reliability |  |  |
+| Docs/DX |  |  |
+| Observability/Ops |  |  |
+| Release Control |  |  |
+
+## Recommendation
+
+`GO`, `GO WITH WARNINGS`, or `NO-GO UNTIL FIXED`
+
+One-sentence reason:
+
+## Launch Blockers
+
+| ID | Area | Finding | Evidence | Impact | Fix |
+| --- | --- | --- | --- | --- | --- |
+| B1 |  |  |  |  |  |
+
+## Warnings
+
+| ID | Area | Finding | Evidence | Impact | Fix |
+| --- | --- | --- | --- | --- | --- |
+| W1 |  |  |  |  |  |
+
+## Nice-To-Haves
+
+| ID | Area | Improvement | Why It Helps |
+| --- | --- | --- | --- |
+| N1 |  |  |  |
+
+## Verified Strengths
+
+- 
+
+## Solana Agent Kit Readiness
+
+Include only when the project uses Solana Agent Kit, MCP, LangChain/Vercel AI tools, or autonomous write actions.
+
+| Area | Status | Evidence | Fix |
+| --- | --- | --- | --- |
+| Tool allowlist |  |  |  |
+| Mainnet write gates |  |  |  |
+| Wallet/key custody |  |  |  |
+| Autonomous limits |  |  |  |
+| Action logging |  |  |  |
+
+## Critical Unknowns
+
+- 
+
+## Prioritized Next Actions
+
+1. 
+2. 
+3. 
+
+## Owner-Facing Summary
+
+Write 3-6 concise sentences that a founder or launch owner can act on immediately.
+```

--- a/skills/solana-launch-readiness/references/scoring-rubric.md
+++ b/skills/solana-launch-readiness/references/scoring-rubric.md
@@ -1,0 +1,51 @@
+# Launch Readiness Scoring Rubric
+
+Use this rubric after collecting evidence. Scores are not a substitute for judgment; they make the final recommendation consistent.
+
+## Category Scores
+
+Score each category from 0 to 3.
+
+| Score | Meaning |
+| --- | --- |
+| 0 | Not present or cannot be verified |
+| 1 | Present but risky, incomplete, stale, or unclear |
+| 2 | Mostly ready with minor gaps |
+| 3 | Launch-ready and evidence-backed |
+
+## Categories
+
+| Category | What To Check |
+| --- | --- |
+| Wallet UX | connect, network mismatch, rejected signatures, pending/failed/confirmed states |
+| Network/RPC | target cluster, RPC config, fallbacks, timeouts, rate limits, secret handling |
+| Addresses/Metadata | program IDs, mints, token metadata, explorer links, authority disclosures |
+| Transaction Reliability | simulation, preflight, ordering, retries, idempotency, confirmation, recovery |
+| Docs/DX | README, env examples, setup, launch addresses, troubleshooting, known limits |
+| Observability/Ops | logs, analytics, transaction failure triage, support channel, incident runbook |
+| Release Control | CI, deploy commands, release tag, rollback/pause path, owner assignments |
+
+## Recommendation Mapping
+
+Use the lowest category scores and blockers to choose:
+
+- `GO`: no blockers, no category below 2, and launch owners assigned.
+- `GO WITH WARNINGS`: no blockers, at most two categories score 1, and the remaining risks have owners.
+- `NO-GO UNTIL FIXED`: any blocker exists, any fund/user-trust critical flow is unverified, secrets are exposed, network config is contradictory, public addresses cannot be verified for the claimed network, or three or more categories score 1 or lower.
+
+## Severity Escalation
+
+Escalate to `blocker` when a finding can plausibly cause:
+
+- users to sign on the wrong network
+- loss of funds or unrecoverable transaction state
+- public launch with wrong program/mint addresses
+- mainnet or public beta launch without verified program/mint chain-state evidence
+- token/NFT launch without relevant mint, freeze, upgrade, or governance authority disclosure
+- exposed private keys, seed phrases, RPC keys, or privileged credentials
+- a core user flow that cannot recover from normal wallet/RPC failure
+- no way for the team to triage failed transactions during launch
+
+Keep as `warning` when there is a workaround and no immediate fund/user-trust risk.
+
+Keep as `nice-to-have` when the issue improves quality but should not affect launch safety or reliability.

--- a/skills/solana-launch-readiness/references/solana-agent-kit.md
+++ b/skills/solana-launch-readiness/references/solana-agent-kit.md
@@ -1,0 +1,48 @@
+# Solana Agent Kit Review Notes
+
+Load this reference when the repository uses Solana Agent Kit, autonomous agents, MCP tools, LangChain tools, Vercel AI SDK tools, or any AI-controlled Solana action.
+
+## Agent Initialization
+
+- Identify where `SolanaAgentKit`, wallet adapters, RPC connections, tool registries, or MCP servers are initialized.
+- Confirm target cluster is explicit and cannot silently fall back to devnet/mainnet in production.
+- Check whether read-only tools and write tools are separated.
+- Check whether public demo mode disables write actions by default.
+
+## Wallet And Key Custody
+
+- Private keys, seed phrases, and keypair JSON must not be committed, printed, or exposed to browser code.
+- Server-side wallets must be loaded from secret storage, not `.env.example`, docs, frontend env vars, or sample configs.
+- Custodial or delegated signing must be described in user-facing docs when relevant.
+- Agent wallets should have scoped balances and recoverable rotation procedures before launch.
+
+## Tool Allowlist And Human Gates
+
+- List every enabled Solana action/tool and classify it as read-only, simulated, or write-capable.
+- Write-capable actions should require explicit human confirmation before mainnet use.
+- Dangerous actions such as transfers, swaps, staking, minting, burning, closing accounts, authority changes, and program upgrades should have separate gates.
+- Autonomous loops must have spending, retry, rate, and timeout limits.
+- Tool prompts should not let untrusted user text bypass write confirmation.
+
+## Transaction And Runtime Safety
+
+- Agent-created transactions should surface simulation logs and final instruction summaries before signing.
+- Agents should use explicit compute budget, priority fee, retry, and blockhash expiry strategies for launch-critical flows.
+- Failed actions should be logged with action name, signature if available, wallet prefix, cluster, sanitized error code, and timestamp.
+- Write actions should be idempotent or have duplicate-submission protection.
+
+## Launch Report Additions
+
+When Solana Agent Kit is present, add a dedicated section to the report:
+
+```markdown
+## Solana Agent Kit Readiness
+
+| Area | Status | Evidence | Fix |
+| --- | --- | --- | --- |
+| Tool allowlist |  |  |  |
+| Mainnet write gates |  |  |  |
+| Wallet/key custody |  |  |  |
+| Autonomous limits |  |  |  |
+| Action logging |  |  |  |
+```

--- a/skills/solana-launch-readiness/references/use-cases.md
+++ b/skills/solana-launch-readiness/references/use-cases.md
@@ -1,0 +1,109 @@
+# Use Cases
+
+Load this reference when deciding whether the skill applies or when writing the owner-facing summary.
+
+## 1. Mainnet Beta Launch Review
+
+User intent:
+
+```text
+We are launching our Solana app on mainnet-beta next week. Review the repo and docs for launch blockers.
+```
+
+Best output:
+
+- identify network/RPC mismatches
+- verify public addresses and explorer links
+- check wallet rejection and failed transaction UX
+- list launch blockers and owners
+
+## 2. Token Or NFT Campaign Readiness
+
+User intent:
+
+```text
+We are about to announce a token/NFT campaign. Check the mint metadata, docs, explorer links, and user flow.
+```
+
+Best output:
+
+- verify mint/program references
+- inspect metadata and user-facing claims
+- check SPL Token vs Token-2022 assumptions and Metaplex metadata for NFT launches
+- check ATA creation, rent, mint/freeze authority, collection authority, and explorer links
+- check disclaimers and support path
+- flag missing authority/governance context when relevant
+
+## 3. DeFi, Trading, Or Payment Flow Readiness
+
+User intent:
+
+```text
+We are launching a paid flow, swap, staking, or checkout experience. Review transaction reliability and support readiness.
+```
+
+Best output:
+
+- inspect slippage, fees, balance/rent checks, token account creation, and price/quote freshness
+- check priority fees, compute budget, latest blockhash, expiry, retry, and duplicate submission handling
+- verify user-facing states for rejected, failed, expired, dropped, and confirmed transactions
+- confirm support can triage from signature, wallet prefix, flow name, sanitized error code, and timestamp
+
+## 4. Program Migration Or Upgrade Readiness
+
+User intent:
+
+```text
+We are migrating or upgrading a Solana program. Check release readiness around addresses, docs, and rollback.
+```
+
+Best output:
+
+- verify old/new program IDs, IDL, upgrade authority, governance/multisig status, and release commit
+- check migration scripts, idempotency, data snapshots, and rollback/pause path
+- keep smart-contract security conclusions tied to audit artifacts only
+- list exact unknowns requiring owner confirmation
+
+## 5. Wallet UX Regression Review
+
+User intent:
+
+```text
+We changed wallet adapter code. Review whether users can recover from common wallet and RPC failures.
+```
+
+Best output:
+
+- inspect connect/disconnect/network mismatch states
+- check rejected signature handling
+- check pending/confirmed/failed/expired transaction states
+- produce repro steps for risky flows
+
+## 6. DevRel Demo Or Hackathon Submission
+
+User intent:
+
+```text
+We need the demo to work for judges and first users. Review setup docs and the happy path.
+```
+
+Best output:
+
+- verify README and env examples
+- check whether new users can run the demo
+- identify stale addresses or devnet/mainnet mismatch
+- provide a short go/no-go list
+
+## 7. Post-Audit Launch Handoff
+
+User intent:
+
+```text
+The program audit is done. Check everything around the app before we launch.
+```
+
+Best output:
+
+- do not repeat the audit
+- review frontend, docs, RPC, monitoring, support, release controls
+- list unknowns that audit reports do not cover

--- a/skills/solana-launch-readiness/scripts/rpc_readiness_probe.mjs
+++ b/skills/solana-launch-readiness/scripts/rpc_readiness_probe.mjs
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+/**
+ * Read-only Solana RPC and chain-state probe.
+ *
+ * Usage:
+ *   node scripts/rpc_readiness_probe.mjs launch-config.json [--timeout-ms 8000]
+ *
+ * Config shape:
+ *   {
+ *     "cluster": "mainnet-beta",
+ *     "rpcEndpoints": ["https://api.mainnet-beta.solana.com"],
+ *     "programs": ["..."],
+ *     "mints": ["..."]
+ *   }
+ *
+ * The script uses raw JSON-RPC only. It never signs or submits transactions.
+ */
+
+import { readFile } from "node:fs/promises";
+import { performance } from "node:perf_hooks";
+
+const args = process.argv.slice(2);
+const configPath = readPositionalArg(args);
+const timeoutMs = readNumberArg(args, "--timeout-ms", 8000);
+
+if (args.includes("--help") || args.includes("-h")) {
+  printUsage();
+  process.exit(0);
+}
+
+if (!configPath) {
+  printUsage();
+  process.exit(2);
+}
+
+const config = JSON.parse(await readFile(configPath, "utf8"));
+const endpoints = config.rpcEndpoints ?? config.rpc_endpoints ?? [];
+const programs = config.programs ?? [];
+const mints = config.mints ?? [];
+
+const result = {
+  cluster: config.cluster ?? config.target_cluster ?? "unknown",
+  rpc: [],
+  programs: [],
+  mints: [],
+  next_step:
+    "Use this read-only evidence in the launch-readiness report; network failures are non-blocking evidence, not proof that the app is broken.",
+};
+
+for (const endpoint of endpoints) {
+  const started = performance.now();
+  const probe = {
+    endpoint: redactUrl(endpoint),
+    ok: false,
+    latencyMs: null,
+    slot: null,
+    latestBlockhash: null,
+    error: null,
+  };
+  try {
+    const [slot, blockhash] = await Promise.all([
+      rpc(endpoint, "getSlot", [{ commitment: "confirmed" }], timeoutMs),
+      rpc(endpoint, "getLatestBlockhash", [{ commitment: "confirmed" }], timeoutMs),
+    ]);
+    probe.ok = true;
+    probe.latencyMs = Math.round(performance.now() - started);
+    probe.slot = slot;
+    probe.latestBlockhash = blockhash?.value?.blockhash ?? null;
+  } catch (error) {
+    probe.error = error instanceof Error ? error.message : String(error);
+  }
+  result.rpc.push(probe);
+}
+
+const accountEndpoint = result.rpc.some((probe) => probe.ok) ? endpoints[result.rpc.findIndex((probe) => probe.ok)] : null;
+if (!accountEndpoint && (programs.length > 0 || mints.length > 0)) {
+  result.next_step =
+    "All RPC endpoint probes failed, so account probes were skipped. Record this as unknown/non-blocking evidence and retry with a reachable read-only endpoint.";
+}
+
+for (const address of programs) {
+  result.programs.push(await readAccount(accountEndpoint, address, "program"));
+}
+
+for (const address of mints) {
+  result.mints.push(await readAccount(accountEndpoint, address, "mint"));
+}
+
+console.log(JSON.stringify(result, null, 2));
+
+async function readAccount(endpoint, address, type) {
+  const item = {
+    address,
+    type,
+    exists: false,
+    executable: null,
+    owner: null,
+    lamports: null,
+    dataLength: null,
+    error: null,
+  };
+  if (!endpoint) {
+    item.error = "missing rpc endpoint";
+    return item;
+  }
+  try {
+    const response = await rpc(
+      endpoint,
+      "getAccountInfo",
+      [address, { commitment: "confirmed", encoding: "base64" }],
+      timeoutMs,
+    );
+    const value = response?.value;
+    if (!value) {
+      return item;
+    }
+    item.exists = true;
+    item.executable = value.executable;
+    item.owner = value.owner;
+    item.lamports = value.lamports;
+    item.dataLength = Array.isArray(value.data) && typeof value.data[0] === "string" ? value.data[0].length : null;
+  } catch (error) {
+    item.error = error instanceof Error ? error.message : String(error);
+  }
+  return item;
+}
+
+async function rpc(endpoint, method, params = [], timeout = 8000) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeout);
+  let response;
+  try {
+    response = await fetch(endpoint, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+      signal: controller.signal,
+    });
+  } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") {
+      throw new Error(`timeout after ${timeout}ms`);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timer);
+  }
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`);
+  }
+  const payload = await response.json();
+  if (payload.error) {
+    throw new Error(payload.error.message ?? JSON.stringify(payload.error));
+  }
+  return payload.result;
+}
+
+function readNumberArg(args, name, fallback) {
+  const index = args.indexOf(name);
+  if (index === -1 || index + 1 >= args.length) {
+    return fallback;
+  }
+  const value = Number(args[index + 1]);
+  return Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+function readPositionalArg(args) {
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--timeout-ms") {
+      index += 1;
+      continue;
+    }
+    if (!arg.startsWith("--")) {
+      return arg;
+    }
+  }
+  return null;
+}
+
+function printUsage() {
+  console.error("Usage: node scripts/rpc_readiness_probe.mjs launch-config.json [--timeout-ms 8000]");
+}
+
+function redactUrl(url) {
+  try {
+    const parsed = new URL(url);
+    for (const key of [...parsed.searchParams.keys()]) {
+      parsed.searchParams.set(key, "<redacted>");
+    }
+    if (parsed.username || parsed.password) {
+      parsed.username = "<redacted>";
+      parsed.password = "<redacted>";
+    }
+    return parsed.toString();
+  } catch {
+    return "<invalid-url>";
+  }
+}

--- a/skills/solana-launch-readiness/scripts/scan_repo.py
+++ b/skills/solana-launch-readiness/scripts/scan_repo.py
@@ -1,0 +1,589 @@
+#!/usr/bin/env python3
+"""Solana launch-readiness repository scanner.
+
+The scanner produces review signals, not final severity. It never signs
+transactions, never calls Solana RPC, and applies best-effort redaction to
+secret-like evidence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+SKIP_DIRS = {
+    ".git",
+    ".next",
+    ".turbo",
+    ".vercel",
+    "node_modules",
+    "target",
+    "dist",
+    "build",
+    "coverage",
+}
+
+PRIVATE_ENV_FILES = {
+    ".env",
+    ".env.local",
+    ".env.production",
+    ".env.development",
+    ".env.test",
+}
+
+LOCK_FILES = {
+    "package-lock.json",
+    "pnpm-lock.yaml",
+    "yarn.lock",
+}
+
+TEXT_EXTS = {
+    ".example",
+    ".json",
+    ".toml",
+    ".yaml",
+    ".yml",
+    ".md",
+    ".txt",
+    ".ts",
+    ".tsx",
+    ".js",
+    ".jsx",
+    ".rs",
+    ".py",
+    ".sh",
+}
+
+SECRET_ASSIGNMENT_RE = re.compile(
+    r"\b([A-Z0-9_]*(?:PRIVATE_KEY|SECRET_KEY|SECRET|SEED_PHRASE|MNEMONIC|RPC_KEY|API_KEY|PROJECT_KEY|ACCESS_TOKEN|AUTH_TOKEN|TOKEN|PASSWORD|DSN)[A-Z0-9_]*)"
+    r"\s*[:=]\s*(\[[^\]\n]{8,}\]|['\"][^'\"]{4,}['\"]|[^'\"\n#,} ]{4,})",
+    re.I,
+)
+
+MNEMONIC_ASSIGNMENT_RE = re.compile(
+    r"\b([A-Z0-9_]*(?:SEED_PHRASE|MNEMONIC)[A-Z0-9_]*)\s*[:=]\s*(['\"])([^'\"]{20,})\2",
+    re.I,
+)
+
+BEARER_RE = re.compile(r"\b(Bearer)\s+[A-Za-z0-9._~+/=-]{12,}", re.I)
+
+URL_RE = re.compile(r"https://[^\s'\"),]+", re.I)
+
+SENSITIVE_URL_KEYS = {
+    "api-key",
+    "apikey",
+    "api_key",
+    "key",
+    "token",
+    "access_token",
+    "auth",
+    "secret",
+    "signature",
+}
+
+PROVIDER_HOST_RE = re.compile(r"(helius|quicknode|quiknode|triton|alchemy|ankr)", re.I)
+
+RPC_ENDPOINT_RE = re.compile(
+    r"https://[^\s'\"),]*(?:api\.mainnet-beta\.solana\.com|api\.devnet\.solana\.com|api\.testnet\.solana\.com|helius|quicknode|triton)[^\s'\"),]*",
+    re.I,
+)
+
+
+@dataclass
+class Finding:
+    kind: str
+    severity: str
+    area: str
+    title: str
+    file: str
+    line: int
+    evidence: str
+    recommendation: str
+
+
+def is_text_candidate(path: Path, include_private_env: bool) -> bool:
+    if path.name in LOCK_FILES:
+        return False
+    if path.name in PRIVATE_ENV_FILES:
+        return include_private_env
+    if path.name in {".env.example", "env.example"}:
+        return True
+    return path.suffix.lower() in TEXT_EXTS
+
+
+def iter_files(root: Path, include_private_env: bool, max_files: int, max_bytes: int) -> tuple[list[Path], list[dict]]:
+    files: list[Path] = []
+    skipped: list[dict] = []
+
+    for path in root.rglob("*"):
+        if any(part in SKIP_DIRS for part in path.parts):
+            continue
+        if not path.is_file():
+            continue
+        if not is_text_candidate(path, include_private_env):
+            continue
+        if path.stat().st_size > max_bytes:
+            skipped.append({"file": str(path.relative_to(root)), "reason": "file too large"})
+            continue
+        if len(files) >= max_files:
+            skipped.append({"file": str(path.relative_to(root)), "reason": "max file limit reached"})
+            continue
+        files.append(path)
+
+    return files, skipped
+
+
+def read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        return path.read_text(encoding="utf-8", errors="ignore")
+
+
+def sanitize_evidence(line: str) -> str:
+    sanitized = line.strip()
+    sanitized = URL_RE.sub(redact_url, sanitized)
+    sanitized = BEARER_RE.sub(r"\1 <redacted>", sanitized)
+    sanitized = MNEMONIC_ASSIGNMENT_RE.sub(lambda m: f"{m.group(1)}=<redacted>", sanitized)
+    sanitized = SECRET_ASSIGNMENT_RE.sub(lambda m: f"{m.group(1)}=<redacted>", sanitized)
+    return sanitized[:260]
+
+
+def redact_url(match: re.Match[str]) -> str:
+    value = match.group(0)
+    try:
+        from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+        parsed = urlsplit(value)
+        query = urlencode(
+            [
+                (key, "<redacted>" if key.lower() in SENSITIVE_URL_KEYS else val)
+                for key, val in parse_qsl(parsed.query, keep_blank_values=True)
+            ]
+        )
+        netloc = parsed.netloc
+        if "@" in netloc:
+            credentials, host = netloc.rsplit("@", 1)
+            if credentials:
+                netloc = f"<redacted>@{host}"
+
+        path = parsed.path
+        if PROVIDER_HOST_RE.search(parsed.netloc) or RPC_ENDPOINT_RE.search(value):
+            path_parts = path.split("/")
+            redacted_parts = []
+            for part in path_parts:
+                if len(part) >= 12 and re.fullmatch(r"[A-Za-z0-9._~+=-]+", part):
+                    redacted_parts.append("<redacted>")
+                else:
+                    redacted_parts.append(part)
+            path = "/".join(redacted_parts)
+        return urlunsplit((parsed.scheme, netloc, path, query, parsed.fragment))
+    except Exception:
+        return "https://<redacted-url>"
+
+
+def add_finding(
+    findings: list[Finding],
+    root: Path,
+    kind: str,
+    severity: str,
+    area: str,
+    title: str,
+    path: Path | None,
+    line: int,
+    evidence: str,
+    recommendation: str,
+) -> None:
+    rel = "." if path is None else str(path.relative_to(root))
+    findings.append(
+        Finding(
+            kind=kind,
+            severity=severity,
+            area=area,
+            title=title,
+            file=rel,
+            line=line,
+            evidence=sanitize_evidence(evidence),
+            recommendation=recommendation,
+        )
+    )
+
+
+def has_file(rel_files: set[str], *names: str) -> bool:
+    lower = {name.lower() for name in rel_files}
+    return any(name.lower() in lower for name in names)
+
+
+def scan_clusters(root: Path, files: list[Path], findings: list[Finding]) -> dict[str, list[dict]]:
+    clusters: dict[str, list[dict]] = {"mainnet-beta": [], "devnet": [], "testnet": [], "localnet": []}
+    for path in files:
+        for idx, line in enumerate(read_text(path).splitlines(), start=1):
+            lowered = line.lower()
+            if "mainnet-beta" in lowered or re.search(r"\bmainnet\b", lowered):
+                clusters["mainnet-beta"].append({"file": str(path.relative_to(root)), "line": idx})
+            for name in ["devnet", "testnet", "localnet"]:
+                if re.search(rf"\b{name}\b", lowered):
+                    clusters[name].append({"file": str(path.relative_to(root)), "line": idx})
+
+    if clusters["mainnet-beta"] and clusters["devnet"]:
+        add_finding(
+            findings,
+            root,
+            "risk",
+            "blocker",
+            "Network/RPC",
+            "Mixed mainnet-beta and devnet references",
+            None,
+            0,
+            "mainnet-beta and devnet both appear across launch docs/config.",
+            "Make the launch target single-source-of-truth and fail closed when production env vars are missing.",
+        )
+    return clusters
+
+
+def scan_file_patterns(root: Path, files: list[Path], findings: list[Finding]) -> None:
+    line_patterns = [
+        (
+            "risk",
+            "blocker",
+            "Secrets",
+            "Possible committed private key or seed phrase",
+            SECRET_ASSIGNMENT_RE,
+            "Remove secrets from git history, rotate the credential, and use secret storage.",
+        ),
+        (
+            "risk",
+            "warning",
+            "Network/RPC",
+            "Direct RPC endpoint reference",
+            RPC_ENDPOINT_RE,
+            "Keep RPC endpoints configurable; document timeout, retry, fallback, and key exposure behavior.",
+        ),
+        (
+            "risk",
+            "blocker",
+            "Transactions",
+            "skipPreflight enabled",
+            re.compile(r"skipPreflight\s*[:=]\s*true", re.I),
+            "Disable skipPreflight or document the exact simulation/rollback reason before public launch.",
+        ),
+        (
+            "signal",
+            "info",
+            "Wallet UX",
+            "Wallet signing flow found",
+            re.compile(r"signTransaction|signAllTransactions|signMessage|wallet\.adapter|WalletAdapter", re.I),
+            "Verify rejected-signature, disconnected-wallet, and wrong-network recovery paths.",
+        ),
+        (
+            "signal",
+            "info",
+            "Transactions",
+            "Transaction send or confirmation flow found",
+            re.compile(r"sendRawTransaction|sendAndConfirm|sendTransaction|confirmTransaction", re.I),
+            "Inspect expiration, retry, duplicate submission, and user-facing error handling.",
+        ),
+        (
+            "signal",
+            "info",
+            "Observability/Ops",
+            "Monitoring or analytics reference found",
+            re.compile(r"sentry|posthog|datadog|grafana|prometheus|analytics|telemetry", re.I),
+            "Confirm events include privacy-safe transaction failure and support triage context.",
+        ),
+    ]
+
+    for path in files:
+        text = read_text(path)
+        for idx, line in enumerate(text.splitlines(), start=1):
+            for kind, severity, area, title, regex, recommendation in line_patterns:
+                if regex.search(line):
+                    add_finding(findings, root, kind, severity, area, title, path, idx, line, recommendation)
+
+        if path.suffix.lower() in {".ts", ".tsx", ".js", ".jsx"}:
+            inspect_code_file(root, path, text, findings)
+
+
+def inspect_code_file(root: Path, path: Path, text: str, findings: list[Finding]) -> None:
+    if "setPending(true)" in text and "catch" in text:
+        catch_blocks = re.findall(r"catch\s*\([^)]*\)\s*\{(?P<body>.*?)\n\s*\}", text, flags=re.S)
+        if catch_blocks and not any("setPending(false)" in block for block in catch_blocks):
+            add_finding(
+                findings,
+                root,
+                "risk",
+                "blocker",
+                "Wallet UX",
+                "Rejected signatures can leave checkout pending",
+                path,
+                line_for(text, "catch"),
+                "catch block does not reset pending state after wallet/RPC failure.",
+                "Reset pending state, show actionable copy, and allow retry/cancel after rejection or RPC failure.",
+            )
+
+    if re.search(r"confirmTransaction\s*\(\s*signature\s*,\s*['\"]confirmed['\"]", text):
+        add_finding(
+            findings,
+            root,
+            "risk",
+            "warning",
+            "Transactions",
+            "Legacy confirmation call lacks blockhash expiry context",
+            path,
+            line_for(text, "confirmTransaction"),
+            "confirmTransaction(signature, \"confirmed\")",
+            "Use latest blockhash plus lastValidBlockHeight, handle expiry, and show retry guidance.",
+        )
+
+    if "sendRawTransaction" in text and "maxRetries" not in text:
+        add_finding(
+            findings,
+            root,
+            "risk",
+            "warning",
+            "Transactions",
+            "sendRawTransaction has no visible maxRetries setting",
+            path,
+            line_for(text, "sendRawTransaction"),
+            "sendRawTransaction call without maxRetries in the same file.",
+            "Set intentional retry behavior and document the user-facing pending/failed state.",
+        )
+
+
+def line_for(text: str, needle: str) -> int:
+    for idx, line in enumerate(text.splitlines(), start=1):
+        if needle in line:
+            return idx
+    return 0
+
+
+def scan_repo_level(root: Path, files: list[Path], rel_files: set[str], findings: list[Finding]) -> None:
+    if not any(Path(name).name.lower().startswith("readme") for name in rel_files):
+        add_finding(
+            findings,
+            root,
+            "risk",
+            "warning",
+            "Docs/DX",
+            "Repository has no README",
+            None,
+            0,
+            "No README-like file was found.",
+            "Add setup, target network, addresses, and launch instructions.",
+        )
+
+    if ".env.example" not in rel_files and "env.example" not in rel_files:
+        add_finding(
+            findings,
+            root,
+            "risk",
+            "warning",
+            "Network/RPC",
+            "Missing environment example",
+            None,
+            0,
+            "No .env.example or env.example file was found.",
+            "Add a sanitized env example with required Solana RPC and network variables.",
+        )
+
+    if "package.json" in rel_files:
+        package = json.loads((root / "package.json").read_text(encoding="utf-8"))
+        scripts = package.get("scripts", {})
+        for script in ["build", "test", "lint"]:
+            if script not in scripts:
+                add_finding(
+                    findings,
+                    root,
+                    "risk",
+                    "warning",
+                    "Release Control",
+                    f"package.json missing {script} script",
+                    root / "package.json",
+                    0,
+                    f"scripts.{script} is not defined.",
+                    f"Add an npm {script} script or document the equivalent release gate.",
+                )
+    else:
+        add_finding(
+            findings,
+            root,
+            "risk",
+            "warning",
+            "Release Control",
+            "Missing package.json",
+            None,
+            0,
+            "No package.json found for frontend/app release checks.",
+            "Document the framework, build command, and release validation commands.",
+        )
+
+    if not any(name.startswith(".github/workflows/") for name in rel_files):
+        add_finding(
+            findings,
+            root,
+            "risk",
+            "warning",
+            "Release Control",
+            "No CI workflow found",
+            None,
+            0,
+            "No .github/workflows file found.",
+            "Add CI or document the release gate used before public launch.",
+        )
+    else:
+        add_finding(
+            findings,
+            root,
+            "strength",
+            "info",
+            "Release Control",
+            "CI workflow found",
+            None,
+            0,
+            "A .github/workflows file exists.",
+            "Confirm it runs the same checks required for launch approval.",
+        )
+
+    if any("launch-config" in name for name in rel_files):
+        add_finding(
+            findings,
+            root,
+            "signal",
+            "info",
+            "Ops",
+            "Launch config artifact found",
+            None,
+            0,
+            "A launch-config file exists.",
+            "Verify owners, rollback/pause commands, target cluster, addresses, and RPC providers are complete.",
+        )
+
+    scan_missing_explorer_and_authority(root, files, findings)
+
+
+def scan_missing_explorer_and_authority(root: Path, files: list[Path], findings: list[Finding]) -> None:
+    for path in files:
+        if path.suffix.lower() not in {".md", ".yaml", ".yml"}:
+            continue
+        text = read_text(path)
+        for idx, line in enumerate(text.splitlines(), start=1):
+            lowered = line.lower()
+            if "explorer" in lowered and "todo" in lowered:
+                add_finding(
+                    findings,
+                    root,
+                    "risk",
+                    "warning",
+                    "Addresses/Metadata",
+                    "Explorer link is missing or marked TODO",
+                    path,
+                    idx,
+                    line,
+                    "Add correct explorer links for every public program, mint, market, and config address.",
+                )
+            if path.suffix.lower() == ".md" and "| todo" in lowered:
+                add_finding(
+                    findings,
+                    root,
+                    "risk",
+                    "warning",
+                    "Addresses/Metadata",
+                    "Explorer link is missing or marked TODO",
+                    path,
+                    idx,
+                    line,
+                    "Add correct explorer links for every public program, mint, market, and config address.",
+                )
+            if "authority" in lowered and "todo" in lowered:
+                add_finding(
+                    findings,
+                    root,
+                    "risk",
+                    "warning",
+                    "Addresses/Metadata",
+                    "Authority status is not disclosed",
+                    path,
+                    idx,
+                    line,
+                    "Disclose upgrade, freeze, mint, or governance authority status when relevant.",
+                )
+            if ("pause_command" in lowered or "rollback_command" in lowered) and "todo" in lowered:
+                add_finding(
+                    findings,
+                    root,
+                    "risk",
+                    "warning",
+                    "Ops",
+                    "Pause or rollback command is missing",
+                    path,
+                    idx,
+                    line,
+                    "Document the exact pause/rollback owner and command before launch day.",
+                )
+
+
+def build_counts(findings: list[Finding], key: str) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for finding in findings:
+        value = getattr(finding, key)
+        counts[value] = counts.get(value, 0) + 1
+    return counts
+
+
+def scan(root: Path, include_private_env: bool = False, max_files: int = 500, max_bytes: int = 512_000) -> dict:
+    findings: list[Finding] = []
+    files, skipped = iter_files(root, include_private_env, max_files, max_bytes)
+    rel_files = {str(p.relative_to(root)) for p in files}
+
+    scan_repo_level(root, files, rel_files, findings)
+    scan_file_patterns(root, files, findings)
+    clusters = scan_clusters(root, files, findings)
+
+    findings.sort(key=lambda item: ({"risk": 0, "signal": 1, "strength": 2}.get(item.kind, 3), item.file, item.line, item.title))
+
+    return {
+        "root": str(root),
+        "summary": {
+            "files_scanned": len(files),
+            "files_skipped": skipped,
+            "finding_counts": build_counts(findings, "kind"),
+            "severity_counts": build_counts(findings, "severity"),
+            "clusters_seen": {name: refs for name, refs in clusters.items() if refs},
+            "private_env_scanned": include_private_env,
+        },
+        "risks": [asdict(f) for f in findings if f.kind == "risk"],
+        "signals": [asdict(f) for f in findings if f.kind == "signal"],
+        "strengths": [asdict(f) for f in findings if f.kind == "strength"],
+        "next_step": "Use these as evidence signals for the full launch-readiness report; manually verify impact before assigning final go/no-go severity.",
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Safely scan a Solana app repo for launch-readiness signals.")
+    parser.add_argument("path", nargs="?", default=".", help="Repository path to scan")
+    parser.add_argument("--pretty", action="store_true", help="Pretty-print JSON output")
+    parser.add_argument("--include-private-env", action="store_true", help="Also scan .env/.env.local/.env.production with secret redaction")
+    parser.add_argument("--max-files", type=int, default=500, help="Maximum text files to scan")
+    parser.add_argument("--max-bytes", type=int, default=512_000, help="Maximum bytes per scanned file")
+    parser.add_argument("--output", help="Write JSON output to this file instead of stdout")
+    args = parser.parse_args()
+
+    root = Path(args.path).resolve()
+    if not root.exists():
+        raise SystemExit(f"Path does not exist: {root}")
+
+    result = scan(root, args.include_private_env, args.max_files, args.max_bytes)
+    payload = json.dumps(result, indent=2 if args.pretty else None, sort_keys=True)
+    if args.output:
+        Path(args.output).write_text(payload + "\n", encoding="utf-8")
+    else:
+        print(payload)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/solana-launch-readiness/scripts/tx_pattern_scan.py
+++ b/skills/solana-launch-readiness/scripts/tx_pattern_scan.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Offline Solana transaction-pattern scanner.
+
+This script looks for transaction reliability patterns in source files. It does
+not execute code, call RPC, sign, or submit transactions.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+SKIP_DIRS = {".git", ".next", ".turbo", "node_modules", "target", "dist", "build", "coverage"}
+CODE_EXTS = {".ts", ".tsx", ".js", ".jsx", ".rs"}
+
+
+@dataclass
+class PatternResult:
+    name: str
+    status: str
+    severity: str
+    evidence: list[str]
+    recommendation: str
+
+
+PATTERNS = [
+    (
+        "latest blockhash",
+        re.compile(r"getLatestBlockhash|recentBlockhash|blockhash", re.I),
+        "missing",
+        "warning",
+        "Fetch a fresh blockhash close to signing time.",
+    ),
+    (
+        "last valid block height",
+        re.compile(r"lastValidBlockHeight", re.I),
+        "missing",
+        "warning",
+        "Track lastValidBlockHeight and surface expired transaction recovery.",
+    ),
+    (
+        "simulation",
+        re.compile(r"simulateTransaction|simulate", re.I),
+        "missing",
+        "warning",
+        "Simulate critical transactions or document why simulation is not used.",
+    ),
+    (
+        "priority fee",
+        re.compile(r"setComputeUnitPrice|microLamports|priority fee|priorityFee", re.I),
+        "missing",
+        "warning",
+        "Use or intentionally omit priority fees based on expected launch congestion.",
+    ),
+    (
+        "compute budget",
+        re.compile(r"ComputeBudgetProgram|setComputeUnitLimit|compute unit", re.I),
+        "missing",
+        "warning",
+        "Set compute limits for complex transactions or document expected units.",
+    ),
+    (
+        "versioned transaction",
+        re.compile(r"VersionedTransaction|TransactionMessage|compileToV0Message", re.I),
+        "missing",
+        "nice-to-have",
+        "Use versioned transactions when account lists or wallet compatibility require it.",
+    ),
+    (
+        "address lookup table",
+        re.compile(r"AddressLookupTable|lookupTable|lookup table", re.I),
+        "missing",
+        "nice-to-have",
+        "Use ALTs when account lists exceed legacy transaction limits.",
+    ),
+    (
+        "explicit retry config",
+        re.compile(r"maxRetries|retry|backoff", re.I),
+        "missing",
+        "warning",
+        "Document retry behavior and avoid duplicate submissions.",
+    ),
+    (
+        "preflight commitment",
+        re.compile(r"preflightCommitment", re.I),
+        "missing",
+        "warning",
+        "Set preflight commitment intentionally for launch-critical flows.",
+    ),
+    (
+        "skip preflight",
+        re.compile(r"skipPreflight\s*[:=]\s*true", re.I),
+        "present-risk",
+        "blocker",
+        "Disable skipPreflight or document the safety reason and compensating checks.",
+    ),
+    (
+        "partial signing",
+        re.compile(r"partialSign|signAllTransactions", re.I),
+        "present-signal",
+        "info",
+        "Verify signature ordering and no existing signatures are dropped.",
+    ),
+]
+
+
+def iter_code(root: Path, max_bytes: int) -> Iterable[Path]:
+    for path in root.rglob("*"):
+        if any(part in SKIP_DIRS for part in path.parts):
+            continue
+        if path.is_file() and path.suffix.lower() in CODE_EXTS and path.stat().st_size <= max_bytes:
+            yield path
+
+
+def read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        return path.read_text(encoding="utf-8", errors="ignore")
+
+
+def collect_matches(root: Path, files: list[Path], regex: re.Pattern[str]) -> list[str]:
+    evidence: list[str] = []
+    for path in files:
+        for idx, line in enumerate(read_text(path).splitlines(), start=1):
+            if regex.search(line):
+                evidence.append(f"{path.relative_to(root)}:{idx}: {line.strip()[:180]}")
+                if len(evidence) >= 5:
+                    return evidence
+    return evidence
+
+
+def scan(root: Path, max_bytes: int = 512_000) -> dict:
+    files = list(iter_code(root, max_bytes))
+    results: list[PatternResult] = []
+
+    for name, regex, mode, severity, recommendation in PATTERNS:
+        evidence = collect_matches(root, files, regex)
+        if mode == "missing":
+            status = "present" if evidence else "missing"
+            result_severity = "info" if evidence else severity
+        elif mode == "present-risk":
+            status = "present-risk" if evidence else "not-found"
+            result_severity = severity if evidence else "info"
+        else:
+            status = "present-signal" if evidence else "not-found"
+            result_severity = severity
+        results.append(PatternResult(name, status, result_severity, evidence, recommendation))
+
+    return {
+        "root": str(root),
+        "summary": {
+            "files_scanned": len(files),
+            "risk_count": sum(1 for item in results if item.severity in {"blocker", "warning"} and item.status in {"missing", "present-risk"}),
+        },
+        "patterns": [asdict(item) for item in results],
+        "next_step": "Use missing and present-risk patterns as manual review prompts; do not treat this as proof of transaction correctness.",
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Scan Solana transaction source patterns without executing code.")
+    parser.add_argument("path", nargs="?", default=".", help="Repository path to scan")
+    parser.add_argument("--pretty", action="store_true", help="Pretty-print JSON output")
+    parser.add_argument("--max-bytes", type=int, default=512_000, help="Maximum bytes per scanned code file")
+    args = parser.parse_args()
+
+    root = Path(args.path).resolve()
+    if not root.exists():
+        raise SystemExit(f"Path does not exist: {root}")
+    print(json.dumps(scan(root, args.max_bytes), indent=2 if args.pretty else None, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds Solana Launch Gate, a Solana AI Kit-compatible release gate for evidence-backed go/no-go launch readiness.

Most Solana skills help agents build, trade, query, or integrate. Solana Launch Gate helps agents decide whether a Solana app, token flow, or autonomous Solana workflow should launch today.

It helps agents review cluster mismatch, wallet UX, RPC/network configuration, program and mint proof, transaction reliability, Solana Agent Kit write-action gates, monitoring, support, authority disclosure, and release ownership before mainnet/public launch.

Maintainer fit:
- progressive SKILL.md entry point
- focused references loaded only when needed
- optional local/read-only evidence scripts
- deterministic fixture and sample NO-GO report
- no signing, no transaction submission, no destructive actions, no secret printing

Validation:
- node scripts/validate-marketplace.js
- python3 skills/solana-launch-readiness/scripts/scan_repo.py skills/solana-launch-readiness --pretty
- python3 skills/solana-launch-readiness/scripts/tx_pattern_scan.py skills/solana-launch-readiness --pretty
- node skills/solana-launch-readiness/scripts/rpc_readiness_probe.mjs --help
- git diff --check
