### PR TITLE
feat: add transaction-landing skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -262,6 +262,12 @@
       "category": "Oracles"
     },
     {
+      "name": "transaction-landing",
+      "source": "./skills/transaction-landing",
+      "description": "Reliably land Solana transactions — right-size compute units, price priority fees, choose a transaction lifetime, rebroadcast safely, and confirm correctly. Provider-agnostic, with the idempotency rules that stop AI agents from double-spending on retry. Covers ComputeBudgetProgram, getRecentPrioritizationFees, simulation-based CU estimation, blockhash expiry, durable nonces, and Jito bundles.",
+      "category": "Infrastructure"
+    },
+    {
       "name": "wallet-analysis",
       "source": "./skills/wallet-analysis",
       "description": "Solana-first wallet analysis with Zerion API — portfolio value, token positions, transactions, charts, and wallet PnL across Solana and multichain wallets. API-first, with hosted MCP and x402 on Solana as no-key options for agents.",

--- a/skills/transaction-landing/SKILL.md
+++ b/skills/transaction-landing/SKILL.md
@@ -1,0 +1,192 @@
+---
+name: transaction-landing
+description: Reliably land Solana transactions — right-size compute units, price priority fees, choose a transaction lifetime, rebroadcast safely, and confirm correctly. Provider-agnostic (works with any RPC) and built for AI agents that sign and send transactions autonomously. Covers ComputeBudgetProgram, getRecentPrioritizationFees, simulateTransaction CU estimation, blockhash expiry, durable nonces, Jito bundles, and the idempotency rules that stop agents from double-spending on retry.
+---
+
+# Transaction Landing — Get Solana Transactions Confirmed, Safely
+
+You are an expert Solana engineer making transactions **land reliably** without overpaying or double-executing. This is the single most common production failure on Solana: a transaction is signed, sent, and then silently dropped during congestion — or worse, an agent "retries" by signing a *new* transaction and accidentally executes the action twice.
+
+This skill is **provider-agnostic**: every technique here works against any standard RPC (`@solana/web3.js` or `@solana/kit`). For provider-accelerated sending, route to the [`helius`](../helius/) (Sender, Priority Fee API) or [`quicknode`](../quicknode/) skills — this skill is the universal layer underneath them.
+
+## Overview
+
+Landing a transaction is five decisions, in order. Get each right and a transaction lands on the next slot; get one wrong and it drops, overpays, or double-spends.
+
+1. **Right-size compute** — simulate to get actual CUs, set a tight `setComputeUnitLimit`. Never ship the default 200k.
+2. **Price the priority fee** — fetch a real-time estimate, never hardcode. Set `setComputeUnitPrice`.
+3. **Choose a lifetime** — recent blockhash (fast, ~60s window) or durable nonce (long-lived, offline, retry-safe).
+4. **Submit + rebroadcast** — sign **once**, then resend the **identical bytes** until it lands or the lifetime expires.
+5. **Confirm correctly** — poll signature status against `lastValidBlockHeight`; a submitted signature is *not* a landed transaction.
+
+> **The agentic trap (read first):** retrying a dropped transaction means **rebroadcasting the same signed bytes** — same signature, idempotent, safe. It does **not** mean signing a *fresh* transaction for the same action. A fresh transaction has a new signature the chain will execute again. This is the #1 way autonomous agents double-spend. See [Agentic Safety](#agentic-safety) — it is the most important section here.
+
+## The Reliability Ladder
+
+Start at the lowest rung that meets your need; climb only when transactions drop.
+
+| Rung | Mechanism | Use when | Skill / API |
+|------|-----------|----------|-------------|
+| 0 | `sendRawTransaction` to a public RPC | devnet, low stakes, low congestion | base `@solana/web3.js` |
+| 1 | + tight CU limit + real priority fee + rebroadcast loop | **mainnet default — covers ~95% of cases** | this skill |
+| 2 | Staked / SWQOS routing (dual-routes to validators + Jito) | time-sensitive trading, mints | [`helius`](../helius/) Sender, [`quicknode`](../quicknode/) |
+| 3 | Jito bundles (atomic, MEV-protected) | bundles that must land together / front-run protection | [escalation.md](references/escalation.md) |
+
+**Most agents only need rung 1.** Reach for 2–3 when you see drops under congestion or need atomic/ordered execution.
+
+## Quick Start
+
+```bash
+npm install @solana/web3.js   # v1.x — most widely deployed
+# or: npm install @solana/kit @solana-program/compute-budget @solana-program/system
+```
+
+The complete, runnable reference implementation is in [`examples/send-and-confirm.ts`](examples/send-and-confirm.ts). The shape:
+
+```typescript
+import {
+  Connection, ComputeBudgetProgram, TransactionMessage,
+  VersionedTransaction, Keypair, TransactionInstruction,
+} from '@solana/web3.js';
+
+async function landTransaction(
+  connection: Connection,
+  payer: Keypair,
+  instructions: TransactionInstruction[],
+): Promise<string> {
+  // 1. RIGHT-SIZE COMPUTE — simulate with a high cap, read actual usage
+  const computeUnits = await estimateComputeUnits(connection, payer, instructions);
+
+  // 2. PRICE THE FEE — real-time estimate, never hardcoded (see references/priority-fees.md)
+  const microLamports = await estimatePriorityFee(connection, instructions);
+
+  // 3. CHOOSE A LIFETIME — recent blockhash here; durable nonce for long windows
+  const { blockhash, lastValidBlockHeight } =
+    await connection.getLatestBlockhash('confirmed');
+
+  // Build: compute-budget instructions MUST come first
+  const message = new TransactionMessage({
+    payerKey: payer.publicKey,
+    recentBlockhash: blockhash,
+    instructions: [
+      ComputeBudgetProgram.setComputeUnitLimit({ units: computeUnits }),
+      ComputeBudgetProgram.setComputeUnitPrice({ microLamports }),
+      ...instructions,
+    ],
+  }).compileToV0Message();
+
+  const tx = new VersionedTransaction(message);
+  tx.sign([payer]);                       // sign ONCE
+  const raw = tx.serialize();             // these exact bytes get rebroadcast
+
+  // 4 + 5. SUBMIT, REBROADCAST, CONFIRM (see references/confirmation.md)
+  return await sendAndConfirm(connection, raw, lastValidBlockHeight, tx.signatures[0]);
+}
+```
+
+## The Five Decisions
+
+### 1. Right-size compute units
+Every transaction has a CU limit. The default (200k) is almost always wrong: too low and the program runs out of CUs and **fails**; too high and you **overpay** the priority fee (which is `price × limit`) *and* lower your effective priority. Simulate first.
+
+```typescript
+const sim = await connection.simulateTransaction(testTx, {
+  replaceRecentBlockhash: true,   // don't need a real one to simulate
+  sigVerify: false,
+});
+const used = sim.value.unitsConsumed ?? 200_000;
+const computeUnits = Math.min(1_400_000, Math.max(1_000, Math.ceil(used * 1.1)));
+```
+Full method, including the 1.4M-cap and per-instruction nuances: [references/compute-units.md](references/compute-units.md).
+
+### 2. Price the priority fee
+Priority fee (microLamports per CU) buys block-inclusion priority. **Never hardcode it** — network conditions shift by the slot. The provider-agnostic baseline is the `getRecentPrioritizationFees` RPC; provider APIs (Helius, QuickNode) give sharper estimates.
+
+```typescript
+const recent = await connection.getRecentPrioritizationFees({
+  lockedWritableAccounts: writableAccountsYourTxTouches,
+});
+const fees = recent.map(r => r.prioritizationFee).filter(f => f > 0).sort((a, b) => a - b);
+const p75 = fees[Math.floor(fees.length * 0.75)] ?? 10_000;   // 75th percentile
+const microLamports = Math.ceil(p75 * 1.2);                    // +20% production buffer
+```
+Percentile strategy, provider APIs, and fee math: [references/priority-fees.md](references/priority-fees.md).
+
+### 3. Choose a transaction lifetime
+- **Recent blockhash** (default): `getLatestBlockhash` → valid ~150 slots (~60–90s). Carries `lastValidBlockHeight`, your expiry signal.
+- **Durable nonce**: a nonce account whose `nonceAdvance` is the first instruction. **Never expires** — sign now, land hours later. Essential for offline signing, multisig, and **agents that need a long retry window**. Details: [references/confirmation.md](references/confirmation.md#durable-nonces).
+
+### 4 + 5. Submit, rebroadcast, confirm
+This is where transactions are won or lost. The robust loop:
+
+```
+sign once → serialize → loop every ~2s {
+    resend the SAME bytes (skipPreflight: true, maxRetries: 0)
+    poll getSignatureStatuses([sig])
+    if confirmed && err == null  → DONE (return signature)
+    if "already processed"       → DONE (it landed — this is success, not an error)
+    if blockHeight > lastValidBlockHeight → EXPIRED (rebuild from scratch; do NOT reuse the action blindly)
+}
+```
+Why resend the same bytes: an RPC may accept a transaction and still drop it from the mempool under load. Rebroadcasting the **identical signature** is free and idempotent — the network dedupes it. Full implementation with the expiry guard: [references/confirmation.md](references/confirmation.md).
+
+## Agentic Safety
+
+These rules exist because an autonomous agent that "just retries" can double-execute real value transfers. (This skill's author proved exactly this class of bug in a live agentic routing API: an interrupted flow that re-built and re-broadcast a *funding* transaction funded a keeper account **twice**.) Treat them as invariants.
+
+- **One logical action = one signed transaction = one signature.** To retry, rebroadcast the *identical* serialized bytes. Never sign a *new* transaction for the same action while the first could still land.
+- **A signature is not a confirmation.** Never declare success — or chain the next action — until `getSignatureStatuses` shows `confirmationStatus` `confirmed`/`finalized` **and** `err == null`.
+- **"Already processed" means it landed.** `sendRawTransaction` throwing `This transaction has already been processed` is a **success** signal. An agent that treats it as a failure and re-issues is how double-spends happen.
+- **Before re-issuing a value transfer, check on-chain state.** If a transaction *might* have landed (timeout, ambiguous error), confirm via `getSignatureStatuses` or read the destination balance **before** building a replacement. Never replace blindly.
+- **Application-layer idempotency keys do not protect the chain.** A new signature is a new transaction. Idempotency must live in the *signature*: rebroadcast the same bytes, or gate on on-chain state.
+- **Use a durable nonce when an action needs a long retry window.** It lets you rebroadcast the *same* transaction for minutes/hours instead of rebuilding (and risking a double) after blockhash expiry.
+
+Expanded with code (safe-retry wrapper, ambiguous-error handling): [references/confirmation.md](references/confirmation.md#agentic-safe-retry).
+
+## Best Practices
+
+- **Simulate before every send** — it catches CU sizing, missing signers, and program errors before you spend a lamport on fees.
+- **Compute-budget instructions go first** — `setComputeUnitLimit` then `setComputeUnitPrice`, before your application instructions.
+- **Add a fee buffer in production** (`×1.2`) — conditions shift between estimate and inclusion.
+- **Refresh fees per transaction** for trading; every 10–20s is fine for ordinary apps.
+- **Devnet ≠ mainnet** — devnet has near-zero priority fees and light congestion. A flow that "works on devnet" still needs rungs 1–3 on mainnet. Test landing under load before shipping.
+- **Confirm with the lower commitment you'll act on** — `confirmed` is usually right for UX; require `finalized` only before irreversible downstream actions.
+
+## Common Errors
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `Blockhash not found` / `block height exceeded` | Lifetime expired before inclusion | Rebuild with a fresh blockhash; or use a durable nonce |
+| Transaction "succeeds" but never appears | Dropped from mempool under congestion | Rebroadcast same bytes + add/raise priority fee (rung 1→2) |
+| `exceeded CUs` / program failed mid-run | CU limit too low | Simulate and raise the limit (step 1) |
+| Fees far higher than expected | Default 200k CU limit × high price | Right-size the CU limit |
+| Agent transferred funds twice | Re-signed a new tx instead of rebroadcasting | Apply [Agentic Safety](#agentic-safety) invariants |
+
+Full catalog: [docs/troubleshooting.md](docs/troubleshooting.md).
+
+## Resources
+
+- [Solana Docs — Retrying Transactions](https://solana.com/docs/core/transactions/retry)
+- [Solana Docs — Prioritization Fees](https://solana.com/developers/guides/advanced/how-to-use-priority-fees)
+- [Solana Docs — Confirmation & Expiration](https://solana.com/docs/advanced/confirmation)
+- [Jito — Bundles & Tips](https://docs.jito.wtf/)
+- Constants (Jito tip accounts, tip-floor API, error strings): [resources/constants.md](resources/constants.md)
+
+## Skill Structure
+
+```
+transaction-landing/
+├── SKILL.md                       # This file — the five decisions + reliability ladder
+├── references/
+│   ├── compute-units.md           # Simulation-based CU sizing, instruction ordering
+│   ├── priority-fees.md           # Fee estimation: getRecentPrioritizationFees + provider APIs
+│   ├── confirmation.md            # Rebroadcast loop, expiry guard, durable nonces, safe-retry
+│   └── escalation.md              # Rung 2–3: staked routing & Jito bundles
+├── examples/
+│   ├── send-and-confirm.ts        # Complete runnable reference implementation (web3.js v1)
+│   └── jito-bundle.ts             # Land an atomic bundle via a Jito tip
+├── resources/
+│   └── constants.md               # Jito tip accounts, tip-floor + fee API endpoints, error strings
+└── docs/
+    └── troubleshooting.md         # Error → cause → fix catalog
+```

--- a/skills/transaction-landing/docs/troubleshooting.md
+++ b/skills/transaction-landing/docs/troubleshooting.md
@@ -1,0 +1,61 @@
+# Troubleshooting
+
+## Transaction "sent successfully" but never confirms
+
+**Cause:** The RPC accepted your bytes, then the transaction was dropped from the mempool before reaching a leader — normal under congestion. A successful `sendTransaction` response is not a confirmation.
+
+**Fix:** Run the rebroadcast-and-confirm loop ([references/confirmation.md](../references/confirmation.md)): resend the **same** serialized bytes every ~2s while polling `getSignatureStatuses`, stopping at blockhash expiry. If it still drops, climb the [reliability ladder](../SKILL.md#the-reliability-ladder) — raise the priority fee (rung 1) or use staked routing (rung 2).
+
+## `TransactionExpiredBlockheightExceededError` / `block height exceeded`
+
+**Cause:** The blockhash's `lastValidBlockHeight` passed before inclusion. The transaction is permanently dead.
+
+**Fix:** Rebuild with a fresh blockhash — **but first verify the original didn't land** (`getSignatureStatuses(..., { searchTransactionHistory: true })`) so you don't double-execute. For long retry windows, switch to a [durable nonce](../references/confirmation.md#durable-nonces), which doesn't expire. See [agentic safe-retry](../references/confirmation.md#agentic-safe-retry).
+
+## `Blockhash not found`
+
+**Cause:** Two flavors — (a) you fetched the blockhash from one RPC and sent to another that hasn't seen that slot yet, or (b) the blockhash already expired.
+
+**Fix:** Fetch the blockhash and send through the **same** RPC (or commitment). Retry the send a few times; if it persists past the validity window, treat it as expired and rebuild.
+
+## Program fails with a compute error / `exceeded CUs`
+
+**Cause:** Your `setComputeUnitLimit` is below actual consumption (or you left the 200k default and the program needs more).
+
+**Fix:** Simulate to read `unitsConsumed`, set the limit to `used × 1.1` ([references/compute-units.md](../references/compute-units.md)). For variable-cost transactions (e.g. multi-pool swaps), simulate the actual instructions you'll send, not a representative sample.
+
+## Fees are far higher than expected
+
+**Cause:** Priority fee = `price × CU limit`. An oversized CU limit (especially the 200k default) multiplies a fair price into a large fee.
+
+**Fix:** Right-size the CU limit. Halving an oversized limit halves the priority fee at the same price.
+
+## Transaction lands but is deprioritized / slow under load
+
+**Cause:** Priority fee too low for current contention, or estimated without `lockedWritableAccounts` so it missed per-account congestion.
+
+**Fix:** Pass the writable accounts your transaction touches to `getRecentPrioritizationFees`, raise the percentile (0.75→0.9 for competitive slots), and add the production buffer ([references/priority-fees.md](../references/priority-fees.md)).
+
+## Agent transferred / funded something twice
+
+**Cause:** On interruption or timeout, the agent signed a **new** transaction for the same action instead of rebroadcasting the original bytes — the chain saw a second signature and executed it again.
+
+**Fix:** Apply the [Agentic Safety](../SKILL.md#agentic-safety) invariants: retry = rebroadcast identical bytes; verify on-chain state before rebuilding; treat `already processed` as success; prefer a durable nonce for value transfers. This is the single most important rule in this skill.
+
+## `already been processed` thrown on send
+
+**Cause:** The transaction already landed; you resent it.
+
+**Fix:** This is **success** — return the signature. Match `already.*processed` and resolve, don't surface it as an error or retry it as a failure.
+
+## Simulation fails but the instructions look correct
+
+**Cause:** Missing signer, stale blockhash, an account not yet created, or the probe omitted a required compute-budget instruction.
+
+**Fix:** Simulate with `sigVerify: false` and `replaceRecentBlockhash: true`, sign the probe with the fee payer, and read `sim.value.logs` — the program logs name the actual failing constraint. Fix that before sending (you'd have paid the base fee for the same failure on-chain).
+
+## Devnet works, mainnet drops
+
+**Cause:** Devnet has near-zero priority fees and light congestion; the same flow on mainnet competes for block space.
+
+**Fix:** Don't validate landing on devnet alone. On mainnet, ship rung 1 (right-sized CU + real fee + rebroadcast) as the baseline and load-test before relying on it; escalate to rungs 2–3 for time-sensitive paths.

--- a/skills/transaction-landing/examples/jito-bundle.ts
+++ b/skills/transaction-landing/examples/jito-bundle.ts
@@ -1,0 +1,153 @@
+/**
+ * jito-bundle.ts — land a transaction through a Jito bundle (rung 3).
+ *
+ * A bundle lands all-or-nothing, in order, in one slot, off the public mempool
+ * (front-run protection). This example bundles a single transaction with a
+ * dynamically-sized tip, submits it to the Block Engine, and polls the bundle
+ * status. The same shape extends to up to 5 transactions.
+ *
+ * Tip accounts are FETCHED at runtime via getTipAccounts — never hardcode them.
+ * The set rotates, and a wrong/stale address sends your tip into the void.
+ *
+ *   npm install @solana/web3.js bs58
+ *   RPC_URL=... SECRET_KEY=... ts-node jito-bundle.ts
+ */
+
+import {
+  Connection,
+  ComputeBudgetProgram,
+  Keypair,
+  PublicKey,
+  SystemProgram,
+  TransactionInstruction,
+  TransactionMessage,
+  VersionedTransaction,
+  LAMPORTS_PER_SOL,
+} from '@solana/web3.js';
+import bs58 from 'bs58';
+
+const RPC_URL = process.env.RPC_URL ?? 'https://api.mainnet-beta.solana.com';
+const BLOCK_ENGINE = 'https://mainnet.block-engine.jito.wtf/api/v1/bundles';
+
+/** Source of truth for tip accounts — fetched live, never hardcoded. */
+async function getTipAccounts(): Promise<PublicKey[]> {
+  const res = await fetch(BLOCK_ENGINE, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'getTipAccounts', params: [] }),
+  });
+  const json = await res.json();
+  if (json.error || !Array.isArray(json.result)) {
+    throw new Error(
+      `getTipAccounts failed (${JSON.stringify(json.error)}). ` +
+        `Do NOT guess addresses — see https://docs.jito.wtf/lowlatencytxnsend/#tip-amount`,
+    );
+  }
+  return (json.result as string[]).map((a) => new PublicKey(a));
+}
+
+async function getDynamicTipLamports(): Promise<number> {
+  // Size the tip from the live tip floor; floor at 0.0001 SOL so it actually lands.
+  const FLOOR = Math.floor(0.0001 * LAMPORTS_PER_SOL);
+  try {
+    const res = await fetch('https://bundles.jito.wtf/api/v1/bundles/tip_floor');
+    const data = await res.json();
+    const sol = data?.[0]?.landed_tips_75th_percentile;
+    if (typeof sol === 'number') return Math.max(Math.floor(sol * LAMPORTS_PER_SOL), FLOOR);
+  } catch {
+    /* fall through to floor */
+  }
+  return FLOOR;
+}
+
+async function buildBundledTx(
+  connection: Connection,
+  payer: Keypair,
+  instructions: TransactionInstruction[],
+  tipAccounts: PublicKey[],
+): Promise<{ base64: string; signature: string }> {
+  const tipLamports = await getDynamicTipLamports();
+  const tipAccount = tipAccounts[Math.floor(Math.random() * tipAccounts.length)];
+
+  const { blockhash } = await connection.getLatestBlockhash('confirmed');
+  const message = new TransactionMessage({
+    payerKey: payer.publicKey,
+    recentBlockhash: blockhash,
+    instructions: [
+      ComputeBudgetProgram.setComputeUnitLimit({ units: 60_000 }),
+      ComputeBudgetProgram.setComputeUnitPrice({ microLamports: 10_000 }),
+      ...instructions,
+      // Tip transfer LAST. The tip pays for bundle inclusion (separate from the priority fee).
+      SystemProgram.transfer({
+        fromPubkey: payer.publicKey,
+        toPubkey: tipAccount,
+        lamports: tipLamports,
+      }),
+    ],
+  }).compileToV0Message();
+
+  const tx = new VersionedTransaction(message);
+  tx.sign([payer]);
+  return {
+    base64: Buffer.from(tx.serialize()).toString('base64'),
+    signature: bs58.encode(tx.signatures[0]),
+  };
+}
+
+async function sendBundle(base64Txs: string[]): Promise<string> {
+  const res = await fetch(BLOCK_ENGINE, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'sendBundle',
+      params: [base64Txs, { encoding: 'base64' }],
+    }),
+  });
+  const json = await res.json();
+  if (json.error) throw new Error(`sendBundle failed: ${JSON.stringify(json.error)}`);
+  return json.result as string; // bundle id
+}
+
+async function confirmBundle(connection: Connection, signature: string): Promise<void> {
+  // Confirm by the contained signature — a landed bundle lands its transactions.
+  for (let i = 0; i < 30; i++) {
+    const { value } = await connection.getSignatureStatuses([signature]);
+    const st = value[0];
+    if (st?.err) throw new Error(`Bundled tx failed: ${JSON.stringify(st.err)}`);
+    if (st?.confirmationStatus === 'confirmed' || st?.confirmationStatus === 'finalized') return;
+    await new Promise((r) => setTimeout(r, 2_000));
+  }
+  throw new Error(`Bundle not confirmed in time: ${signature}`);
+}
+
+async function main() {
+  if (!process.env.SECRET_KEY) throw new Error('Set SECRET_KEY (bs58) — mainnet bundle costs real SOL.');
+  const connection = new Connection(RPC_URL, 'confirmed');
+  const payer = Keypair.fromSecretKey(bs58.decode(process.env.SECRET_KEY));
+
+  const tipAccounts = await getTipAccounts();
+  const instructions = [
+    SystemProgram.transfer({
+      fromPubkey: payer.publicKey,
+      toPubkey: payer.publicKey,
+      lamports: 1_000,
+    }),
+  ];
+
+  const { base64, signature } = await buildBundledTx(connection, payer, instructions, tipAccounts);
+  const bundleId = await sendBundle([base64]);
+  console.log(`Bundle submitted: ${bundleId}`);
+  await confirmBundle(connection, signature);
+  console.log(`Landed: https://explorer.solana.com/tx/${signature}`);
+}
+
+if (require.main === module) {
+  main().catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });
+}
+
+export { getTipAccounts, getDynamicTipLamports, buildBundledTx, sendBundle, confirmBundle };

--- a/skills/transaction-landing/examples/send-and-confirm.ts
+++ b/skills/transaction-landing/examples/send-and-confirm.ts
@@ -1,0 +1,242 @@
+/**
+ * send-and-confirm.ts — complete, runnable reference for reliably landing a
+ * Solana transaction with @solana/web3.js v1.x.
+ *
+ * Implements all five decisions from SKILL.md:
+ *   1. right-size compute units (simulate)
+ *   2. price the priority fee (getRecentPrioritizationFees, percentile + buffer)
+ *   3. choose a lifetime (recent blockhash + lastValidBlockHeight)
+ *   4. submit + rebroadcast the SAME signed bytes
+ *   5. confirm against signature status, stop at blockhash expiry
+ *
+ * Plus the agentic safe-retry wrapper that verifies on-chain state before
+ * rebuilding, so an interrupted run never double-executes.
+ *
+ *   npm install @solana/web3.js bs58
+ *   RPC_URL=https://api.devnet.solana.com ts-node send-and-confirm.ts
+ */
+
+import {
+  Connection,
+  ComputeBudgetProgram,
+  Keypair,
+  PublicKey,
+  SystemProgram,
+  TransactionInstruction,
+  TransactionMessage,
+  VersionedTransaction,
+  LAMPORTS_PER_SOL,
+} from '@solana/web3.js';
+import bs58 from 'bs58';
+
+const RPC_URL = process.env.RPC_URL ?? 'https://api.devnet.solana.com';
+
+// ---------------------------------------------------------------------------
+// 1. Right-size compute units
+// ---------------------------------------------------------------------------
+async function estimateComputeUnits(
+  connection: Connection,
+  payer: Keypair,
+  instructions: TransactionInstruction[],
+): Promise<number> {
+  const { blockhash } = await connection.getLatestBlockhash('confirmed');
+  const probe = new VersionedTransaction(
+    new TransactionMessage({
+      payerKey: payer.publicKey,
+      recentBlockhash: blockhash,
+      instructions: [
+        ComputeBudgetProgram.setComputeUnitLimit({ units: 1_400_000 }),
+        ...instructions,
+      ],
+    }).compileToV0Message(),
+  );
+  probe.sign([payer]);
+
+  const sim = await connection.simulateTransaction(probe, {
+    replaceRecentBlockhash: true,
+    sigVerify: false,
+  });
+  if (sim.value.err) {
+    throw new Error(
+      `Simulation failed: ${JSON.stringify(sim.value.err)}\n${sim.value.logs?.join('\n')}`,
+    );
+  }
+  const used = sim.value.unitsConsumed ?? 200_000;
+  return Math.min(1_400_000, Math.max(1_000, Math.ceil(used * 1.1)));
+}
+
+// ---------------------------------------------------------------------------
+// 2. Price the priority fee (provider-agnostic baseline)
+// ---------------------------------------------------------------------------
+async function estimatePriorityFee(
+  connection: Connection,
+  writableAccounts: PublicKey[],
+  percentile = 0.75,
+): Promise<number> {
+  const recent = await connection.getRecentPrioritizationFees({
+    lockedWritableAccounts: writableAccounts,
+  });
+  const fees = recent
+    .map((r) => r.prioritizationFee)
+    .filter((f) => f > 0)
+    .sort((a, b) => a - b);
+  if (fees.length === 0) return 10_000;
+  const pick = fees[Math.min(fees.length - 1, Math.floor(fees.length * percentile))];
+  return Math.ceil(pick * 1.2);
+}
+
+// ---------------------------------------------------------------------------
+// 3 + build. Assemble a signed, ready-to-broadcast transaction
+// ---------------------------------------------------------------------------
+interface Built {
+  raw: Uint8Array;
+  signature: string;
+  lastValidBlockHeight: number;
+}
+
+async function buildTransaction(
+  connection: Connection,
+  payer: Keypair,
+  instructions: TransactionInstruction[],
+  writableAccounts: PublicKey[],
+): Promise<Built> {
+  const computeUnits = await estimateComputeUnits(connection, payer, instructions);
+  const microLamports = await estimatePriorityFee(connection, writableAccounts);
+
+  const { blockhash, lastValidBlockHeight } =
+    await connection.getLatestBlockhash('confirmed');
+
+  const message = new TransactionMessage({
+    payerKey: payer.publicKey,
+    recentBlockhash: blockhash,
+    instructions: [
+      ComputeBudgetProgram.setComputeUnitLimit({ units: computeUnits }),
+      ComputeBudgetProgram.setComputeUnitPrice({ microLamports }),
+      ...instructions,
+    ],
+  }).compileToV0Message();
+
+  const tx = new VersionedTransaction(message);
+  tx.sign([payer]); // sign ONCE — these exact bytes get rebroadcast
+
+  return {
+    raw: tx.serialize(),
+    signature: bs58.encode(tx.signatures[0]),
+    lastValidBlockHeight,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 4 + 5. Submit, rebroadcast the same bytes, confirm, stop at expiry
+// ---------------------------------------------------------------------------
+class BlockhashExpiredError extends Error {
+  constructor(public signature: string) {
+    super(`Blockhash expired before confirmation: ${signature}`);
+  }
+}
+
+async function sendAndConfirm(
+  connection: Connection,
+  built: Built,
+  { pollMs = 2_000, timeoutMs = 90_000 } = {},
+): Promise<string> {
+  const { raw, signature, lastValidBlockHeight } = built;
+  const start = Date.now();
+
+  while (Date.now() - start < timeoutMs) {
+    try {
+      await connection.sendRawTransaction(raw, { skipPreflight: true, maxRetries: 0 });
+    } catch (e: any) {
+      if (/already.*processed/i.test(e.message)) return signature; // landed
+      // otherwise let status polling decide
+    }
+
+    const { value } = await connection.getSignatureStatuses([signature]);
+    const st = value[0];
+    if (st) {
+      if (st.err) throw new Error(`Transaction failed on-chain: ${JSON.stringify(st.err)}`);
+      if (st.confirmationStatus === 'confirmed' || st.confirmationStatus === 'finalized') {
+        return signature;
+      }
+    }
+
+    const height = await connection.getBlockHeight('confirmed');
+    if (height > lastValidBlockHeight) throw new BlockhashExpiredError(signature);
+
+    await new Promise((r) => setTimeout(r, pollMs));
+  }
+  throw new Error(`Confirmation timed out (still unexpired): ${signature}`);
+}
+
+// ---------------------------------------------------------------------------
+// Agentic safe-retry: verify on-chain state before rebuilding (never double-spend)
+// ---------------------------------------------------------------------------
+async function landWithSafeRetry(
+  connection: Connection,
+  build: () => Promise<Built>,
+  maxRebuilds = 3,
+): Promise<string> {
+  for (let attempt = 0; attempt < maxRebuilds; attempt++) {
+    const built = await build();
+    try {
+      return await sendAndConfirm(connection, built);
+    } catch (e) {
+      if (!(e instanceof BlockhashExpiredError)) throw e; // real on-chain failure: don't retry
+
+      // EXPIRED is ambiguous — the prior tx might have landed in a race. Verify.
+      const { value } = await connection.getSignatureStatuses([e.signature], {
+        searchTransactionHistory: true,
+      });
+      if (value[0] && !value[0].err) return e.signature; // it DID land — do not resend
+      // confirmed not-landed → safe to rebuild with a fresh blockhash
+    }
+  }
+  throw new Error('Exhausted safe rebuild attempts without landing');
+}
+
+// ---------------------------------------------------------------------------
+// Demo: land a 0.001 SOL self-transfer on devnet
+// ---------------------------------------------------------------------------
+async function main() {
+  const connection = new Connection(RPC_URL, 'confirmed');
+  const payer = process.env.SECRET_KEY
+    ? Keypair.fromSecretKey(bs58.decode(process.env.SECRET_KEY))
+    : Keypair.generate();
+
+  if (!process.env.SECRET_KEY) {
+    console.log('No SECRET_KEY set — airdropping 0.5 SOL on devnet for the demo...');
+    const sig = await connection.requestAirdrop(payer.publicKey, 0.5 * LAMPORTS_PER_SOL);
+    await connection.confirmTransaction(sig, 'confirmed');
+  }
+
+  const instructions = [
+    SystemProgram.transfer({
+      fromPubkey: payer.publicKey,
+      toPubkey: payer.publicKey, // self-transfer for a harmless demo
+      lamports: 0.001 * LAMPORTS_PER_SOL,
+    }),
+  ];
+  const writableAccounts = [payer.publicKey];
+
+  const signature = await landWithSafeRetry(connection, () =>
+    buildTransaction(connection, payer, instructions, writableAccounts),
+  );
+
+  console.log(`Landed: https://explorer.solana.com/tx/${signature}?cluster=devnet`);
+}
+
+if (require.main === module) {
+  main().catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });
+}
+
+export {
+  estimateComputeUnits,
+  estimatePriorityFee,
+  buildTransaction,
+  sendAndConfirm,
+  landWithSafeRetry,
+  BlockhashExpiredError,
+};

--- a/skills/transaction-landing/references/compute-units.md
+++ b/skills/transaction-landing/references/compute-units.md
@@ -1,0 +1,103 @@
+# Compute Units — Right-Sizing the CU Limit
+
+## Why it matters
+
+Two numbers govern what a transaction pays beyond the 5,000-lamport base fee:
+
+```
+priority fee (lamports) = ceil( computeUnitPrice (microLamports) × computeUnitLimit / 1_000_000 )
+```
+
+- **`computeUnitLimit`** — how many CUs you reserve. Default when unset: `200,000 × number_of_instructions`, capped at `1,400,000`.
+- **`computeUnitPrice`** — microLamports paid per CU (see [priority-fees.md](priority-fees.md)).
+
+The limit cuts both ways:
+
+- **Too low** → the runtime aborts mid-execution with a compute error and the transaction **fails on-chain** (you still pay the base fee).
+- **Too high** → you **overpay** (fee scales with the limit) *and* schedulers deprioritize you, because requesting CUs close to actual usage is itself a priority signal.
+
+**Never ship the default.** Simulate, then set a tight limit with a small margin.
+
+## Simulation-based estimation
+
+```typescript
+import {
+  Connection, ComputeBudgetProgram, TransactionMessage,
+  VersionedTransaction, Keypair, TransactionInstruction,
+} from '@solana/web3.js';
+
+async function estimateComputeUnits(
+  connection: Connection,
+  payer: Keypair,
+  instructions: TransactionInstruction[],
+): Promise<number> {
+  // Build a probe tx with the MAX limit so simulation never aborts early.
+  const { blockhash } = await connection.getLatestBlockhash('confirmed');
+  const probe = new VersionedTransaction(
+    new TransactionMessage({
+      payerKey: payer.publicKey,
+      recentBlockhash: blockhash,
+      instructions: [
+        ComputeBudgetProgram.setComputeUnitLimit({ units: 1_400_000 }),
+        ...instructions,
+      ],
+    }).compileToV0Message(),
+  );
+  probe.sign([payer]);
+
+  const sim = await connection.simulateTransaction(probe, {
+    replaceRecentBlockhash: true,  // simulate against a fresh slot; ignore staleness
+    sigVerify: false,              // don't require valid sigs to simulate
+  });
+
+  if (sim.value.err) {
+    throw new Error(`Simulation failed: ${JSON.stringify(sim.value.err)}\n${sim.value.logs?.join('\n')}`);
+  }
+
+  const used = sim.value.unitsConsumed ?? 200_000;
+  // +10% margin absorbs run-to-run variance; floor 1,000; cap 1.4M.
+  return Math.min(1_400_000, Math.max(1_000, Math.ceil(used * 1.1)));
+}
+```
+
+### Why the margin
+On-chain CU consumption is not perfectly deterministic across slots — account state, sysvar reads, and CPI depth shift it slightly. A 10% margin is the common production default. For transactions whose CU usage depends on variable input (e.g. a swap that routes through a different number of pools), simulate the *actual* instructions you'll send, not a representative one.
+
+## Instruction ordering (required)
+
+The compute-budget instructions must precede your application instructions:
+
+```typescript
+const instructions = [
+  ComputeBudgetProgram.setComputeUnitLimit({ units: computeUnits }),  // 1st
+  ComputeBudgetProgram.setComputeUnitPrice({ microLamports }),        // 2nd
+  ...applicationInstructions,                                         // then your logic
+  // ...optional Jito tip transfer LAST (see escalation.md)
+];
+```
+
+Include **each compute-budget instruction at most once**. A duplicate `setComputeUnitLimit` (e.g. one in your app instructions and one in a wrapper) makes only the first take effect and wastes space — a common, silent bug.
+
+## @solana/kit equivalent
+
+```typescript
+import {
+  getSetComputeUnitLimitInstruction,
+  getSetComputeUnitPriceInstruction,
+} from '@solana-program/compute-budget';
+
+const m = pipe(
+  createTransactionMessage({ version: 0 }),
+  (m) => setTransactionMessageFeePayerSigner(signer, m),
+  (m) => setTransactionMessageLifetimeUsingBlockhash(blockhash, m),
+  (m) => appendTransactionMessageInstruction(getSetComputeUnitLimitInstruction({ units: computeUnits }), m),
+  (m) => appendTransactionMessageInstruction(getSetComputeUnitPriceInstruction({ microLamports }), m),
+  // ...append application instructions
+);
+```
+
+`@solana/kit` also ships `estimateComputeUnitLimitFactory({ rpc })`, which wraps the simulate-and-pad flow above — prefer it when you're already on kit.
+
+## Cost intuition
+
+A transaction requesting **200,000 CU at 100,000 microLamports/CU** pays `200_000 × 100_000 / 1e6 = 20,000` lamports in priority fee. The *same* work right-sized to **50,000 CU** pays `5,000` lamports — **4× cheaper** for strictly better priority. Right-sizing is the highest-leverage thing you can do for cost.

--- a/skills/transaction-landing/references/confirmation.md
+++ b/skills/transaction-landing/references/confirmation.md
@@ -1,0 +1,128 @@
+# Confirmation — Rebroadcast, Expiry, Durable Nonces, Safe Retry
+
+A successful `sendTransaction` RPC response means *the RPC accepted your bytes* — not that the transaction landed. Under congestion, RPCs routinely accept a transaction and then drop it from the mempool before it reaches a leader. **Landing is your job:** rebroadcast the same bytes and poll until the chain confirms or the lifetime expires.
+
+## The rebroadcast-and-confirm loop
+
+```typescript
+import { Connection } from '@solana/web3.js';
+
+async function sendAndConfirm(
+  connection: Connection,
+  rawTx: Uint8Array,           // tx.serialize() — signed ONCE, reused every resend
+  lastValidBlockHeight: number,
+  signature: string,           // bs58 of tx.signatures[0]
+  { pollMs = 2_000, timeoutMs = 90_000 } = {},
+): Promise<string> {
+  const start = Date.now();
+
+  while (Date.now() - start < timeoutMs) {
+    // (Re)broadcast the IDENTICAL bytes. Idempotent: the network dedupes by signature.
+    try {
+      await connection.sendRawTransaction(rawTx, { skipPreflight: true, maxRetries: 0 });
+    } catch (e: any) {
+      // "already been processed" == it LANDED. Success, not failure.
+      if (/already.*processed/i.test(e.message)) return signature;
+      // Any other send error: fall through and let status polling decide.
+    }
+
+    // Did it confirm?
+    const { value } = await connection.getSignatureStatuses([signature]);
+    const st = value[0];
+    if (st) {
+      if (st.err) throw new Error(`Transaction failed on-chain: ${JSON.stringify(st.err)}`);
+      if (st.confirmationStatus === 'confirmed' || st.confirmationStatus === 'finalized') {
+        return signature;
+      }
+    }
+
+    // Has the blockhash lifetime expired? If so it can NEVER land — stop.
+    const height = await connection.getBlockHeight('confirmed');
+    if (height > lastValidBlockHeight) {
+      throw new BlockhashExpiredError(signature);   // see safe-retry below
+    }
+
+    await new Promise(r => setTimeout(r, pollMs));
+  }
+  throw new Error(`Confirmation timed out (still unexpired): ${signature}`);
+}
+```
+
+### Why resend the same bytes (not `maxRetries`)
+`sendRawTransaction({ maxRetries: N })` delegates rebroadcast to the RPC's own loop, which is opaque and stops when the RPC decides. Setting `maxRetries: 0` and resending yourself gives you control over cadence and a hard stop at blockhash expiry. Resending is safe because the bytes — and therefore the signature — are identical; validators dedupe duplicate signatures.
+
+### Expiry is the real deadline
+A transaction is dead the moment `currentBlockHeight > lastValidBlockHeight` (~150 slots, 60–90s after the blockhash). Polling `getSignatureStatuses` forever is pointless past that — it will never confirm. Always gate the loop on block height, not just a wall-clock timeout.
+
+### Commitment levels
+- `processed` — seen by one node; can still be rolled back. Don't act on it.
+- `confirmed` — supermajority voted; safe for most UX and chaining. **Default.**
+- `finalized` — rooted, irreversible. Require it only before irreversible downstream actions (off-ramp, cross-chain message, accounting settlement).
+
+## Durable nonces
+
+Recent blockhashes expire in ~90s. When you need a transaction to stay valid for minutes or hours — offline signing, multisig collection, or an **agent that may retry over a long window** — use a durable nonce instead.
+
+A nonce account stores a "nonce" that serves as the transaction's blockhash and only advances when consumed. Mechanics:
+
+1. Create a nonce account once (`SystemProgram.createNonceAccount`); fund it rent-exempt.
+2. Read the current nonce: `connection.getNonce(nonceAccount)` → `nonce` value.
+3. Make `SystemProgram.nonceAdvance({ noncePubkey, authorizedPubkey })` the **first** instruction.
+4. Use the nonce value as `recentBlockhash` when compiling the message.
+
+The transaction stays valid until the nonce advances (i.e. until *this* transaction lands). That makes the same signed bytes rebroadcastable indefinitely — the ideal substrate for safe agentic retry, because you never have to rebuild (and risk a double).
+
+```typescript
+const nonceInfo = await connection.getNonce(nonceAccount);
+const message = new TransactionMessage({
+  payerKey: payer.publicKey,
+  recentBlockhash: nonceInfo!.nonce,        // the durable nonce, not a blockhash
+  instructions: [
+    SystemProgram.nonceAdvance({ noncePubkey: nonceAccount, authorizedPubkey: payer.publicKey }),
+    ComputeBudgetProgram.setComputeUnitLimit({ units }),
+    ComputeBudgetProgram.setComputeUnitPrice({ microLamports }),
+    ...applicationInstructions,
+  ],
+}).compileToV0Message();
+```
+
+## Agentic safe-retry
+
+When `sendAndConfirm` throws `BlockhashExpiredError`, an autonomous agent must **not** reflexively rebuild and resend — the original might have landed in a race. Decide from on-chain truth:
+
+```typescript
+class BlockhashExpiredError extends Error {
+  constructor(public signature: string) { super(`Blockhash expired before confirmation: ${signature}`); }
+}
+
+async function landWithSafeRetry(
+  connection: Connection,
+  build: () => Promise<{ raw: Uint8Array; signature: string; lastValidBlockHeight: number }>,
+  maxRebuilds = 3,
+): Promise<string> {
+  for (let attempt = 0; attempt < maxRebuilds; attempt++) {
+    const { raw, signature, lastValidBlockHeight } = await build();
+    try {
+      return await sendAndConfirm(connection, raw, lastValidBlockHeight, signature);
+    } catch (e) {
+      if (!(e instanceof BlockhashExpiredError)) throw e;   // on-chain failure: never retry
+
+      // EXPIRED is ambiguous: the prior tx might still have landed. Verify before rebuilding.
+      const { value } = await connection.getSignatureStatuses([e.signature], {
+        searchTransactionHistory: true,
+      });
+      if (value[0] && !value[0].err) return e.signature;     // it DID land — do not resend
+      // Confirmed not-landed → safe to rebuild with a fresh blockhash and try again.
+    }
+  }
+  throw new Error('Exhausted safe rebuild attempts without landing');
+}
+```
+
+### The invariants (see SKILL.md → Agentic Safety)
+1. Retry = **rebroadcast identical bytes**, never sign a fresh transaction for the same action while the first could land.
+2. Rebuild **only** after confirming the prior signature did **not** land (`searchTransactionHistory: true`).
+3. `already processed` and a no-error status both mean **success** — return, don't resend.
+4. For value transfers, prefer a **durable nonce** so retry never requires a rebuild.
+
+This is the exact failure mode behind real agentic double-spends: a flow that, on interruption, rebuilt and rebroadcast a *funding* transaction and funded the target twice. Verifying on-chain state before rebuilding is what prevents it.

--- a/skills/transaction-landing/references/escalation.md
+++ b/skills/transaction-landing/references/escalation.md
@@ -1,0 +1,63 @@
+# Escalation — Rungs 2 & 3 When the Base Path Drops
+
+Rung 1 (right-sized CU + real priority fee + rebroadcast loop) lands the large majority of transactions. Climb when you still see drops under congestion, or when you need **atomic** or **front-run-protected** execution.
+
+## Rung 2 — Staked / SWQOS routing
+
+Public RPCs forward your transaction to a leader on a best-effort, unstaked path that is the first thing shed under load. **Stake-weighted Quality of Service (SWQOS)** providers forward through staked connections that leaders prioritize, and often dual-route to both validators and Jito simultaneously.
+
+You don't build this — you point the same right-sized, fee-bearing transaction at a provider endpoint:
+
+- **Helius Sender** — dual-routes to validators + Jito; free tier; requires `skipPreflight: true`, `maxRetries: 0`, and a Jito tip. Full request format and regional endpoints: the [`helius`](../../helius/) skill, `references/sender.md`.
+- **QuickNode** — staked sending + `qn_estimatePriorityFees`. See the [`quicknode`](../../quicknode/) skill.
+- **Triton**, **Jito ShredStream** consumers, and other stake-weighted RPCs expose equivalents.
+
+The transaction is identical to rung 1; only the **submission endpoint** changes. Keep your rebroadcast-and-confirm loop ([confirmation.md](confirmation.md)) — staked routing improves inclusion odds, it does not replace confirmation polling.
+
+## Rung 3 — Jito bundles (atomic + MEV-protected)
+
+A **bundle** is an ordered list of up to 5 transactions that land **all-or-nothing, in order, in a single slot**. Use it when:
+
+- multiple transactions must land **together** (e.g. open + hedge, or a multi-leg arb),
+- you need **front-run/sandwich protection** (bundles aren't exposed to the public mempool), or
+- you want a guaranteed **ordering** the public mempool can't promise.
+
+### How it works
+
+1. Include a **tip**: a `SystemProgram.transfer` to a Jito **tip account** (one of the 8 — pick randomly per send; list in [resources/constants.md](../resources/constants.md)). The tip is what pays for bundle inclusion — it is separate from the priority fee.
+2. Size the tip dynamically from the **tip-floor API** (`https://bundles.jito.wtf/api/v1/bundles/tip_floor`); use `max(75th_percentile, 0.0001 SOL)`. Tips that are too low simply don't land.
+3. Base64-encode each signed transaction and submit the array to the Block Engine `sendBundle` JSON-RPC.
+4. Poll bundle status with `getBundleStatuses` (or confirm the contained signatures normally).
+
+The tip can ride in any transaction in the bundle — commonly the last. A runnable single-transaction example (tip + submit + poll) is in [examples/jito-bundle.ts](../examples/jito-bundle.ts).
+
+### Block Engine endpoints (regional)
+
+```
+https://mainnet.block-engine.jito.wtf/api/v1/bundles      # global
+https://amsterdam.mainnet.block-engine.jito.wtf/api/v1/bundles
+https://frankfurt.mainnet.block-engine.jito.wtf/api/v1/bundles
+https://ny.mainnet.block-engine.jito.wtf/api/v1/bundles
+https://tokyo.mainnet.block-engine.jito.wtf/api/v1/bundles
+```
+
+Pick the region nearest your infrastructure. Devnet: `https://dallas.devnet.block-engine.jito.wtf/api/v1/bundles`.
+
+### Bundle rules that bite
+
+- **Max 5 transactions** per bundle; total size limits apply.
+- **All-or-nothing**: if any transaction would fail, the *whole* bundle is dropped — simulate each first.
+- **Tip is not a priority fee**: a bundle still wants right-sized CUs and a normal priority fee on its transactions *plus* the Jito tip.
+- **No partial landing**: never assume a subset landed. Confirm the bundle (or every contained signature) before chaining actions — the [agentic-safety](confirmation.md#agentic-safe-retry) invariants apply per signature.
+
+## Choosing a rung
+
+| Need | Rung |
+|------|------|
+| Ordinary mainnet transaction | 1 |
+| Time-sensitive trade/mint that keeps dropping | 2 |
+| Multiple txs must land together / in order | 3 |
+| Front-run / sandwich protection | 3 |
+| Devnet / low stakes | 0–1 |
+
+Don't over-escalate: bundles and high tips cost real SOL. Climb only to the rung your failure mode requires.

--- a/skills/transaction-landing/references/priority-fees.md
+++ b/skills/transaction-landing/references/priority-fees.md
@@ -1,0 +1,84 @@
+# Priority Fees — Estimation Strategy
+
+Priority fee is **microLamports per compute unit**, set with `ComputeBudgetProgram.setComputeUnitPrice`. It buys block-inclusion priority during congestion. The cardinal rule: **never hardcode it.** A fee that lands a transaction at 2am can be 50× too low during a mint. Estimate in real time, every send for trading.
+
+## Baseline (provider-agnostic): `getRecentPrioritizationFees`
+
+Available on any standard RPC — no API key, no provider lock-in. Returns the prioritization fee paid per slot over the recent window (up to 150 slots).
+
+```typescript
+import { Connection, PublicKey } from '@solana/web3.js';
+
+async function estimatePriorityFee(
+  connection: Connection,
+  writableAccounts: PublicKey[],  // the WRITABLE accounts your tx touches
+  percentile = 0.75,              // 0.5 normal, 0.75 swaps/trades, 0.9 competitive
+): Promise<number> {
+  const recent = await connection.getRecentPrioritizationFees({
+    lockedWritableAccounts: writableAccounts,
+  });
+
+  const fees = recent
+    .map(r => r.prioritizationFee)
+    .filter(f => f > 0)             // drop zero-fee slots; they skew the floor down
+    .sort((a, b) => a - b);
+
+  if (fees.length === 0) return 10_000;          // sane floor when the window is quiet
+  const pick = fees[Math.min(fees.length - 1, Math.floor(fees.length * percentile))];
+  return Math.ceil(pick * 1.2);                  // +20% production buffer
+}
+```
+
+### Why pass `lockedWritableAccounts`
+Congestion is **per-account**, not global. A transaction writing to a hot AMM pool competes with everyone else writing that pool — a global average underprices you. Pass the program/state accounts your instructions write to (the pool, your token accounts, the market) so the estimate reflects *your* contention. Passing nothing gives a network-wide average that is usually too low for hot paths.
+
+### Percentile guidance
+
+| Situation | Percentile | Rationale |
+|-----------|-----------|-----------|
+| Ordinary transfer, non-urgent | 0.50 | Median lands within a few slots |
+| DEX swap, NFT purchase | 0.75 | Time-sensitive; next-slot likely |
+| Arbitrage, liquidation, competitive mint | 0.90+ | Must win the slot |
+
+Always add a buffer (`×1.2` shown) on top — the window is historical and conditions move forward.
+
+## Sharper: provider fee APIs
+
+Dedicated APIs analyze program-specific demand and return calibrated levels. Prefer them when available — route to the relevant skill rather than reimplementing:
+
+- **Helius `getPriorityFeeEstimate`** — pass `accountKeys` or the serialized `transaction`; returns `priorityFeeEstimate` plus `min/low/medium/high/veryHigh/unsafeMax` levels. See the [`helius`](../../helius/) skill (`references/priority-fees.md`).
+- **QuickNode `qn_estimatePriorityFees`** — per-program estimates with percentile breakdowns. See the [`quicknode`](../../quicknode/) skill.
+- **Triton** and other stake-weighted providers expose similar endpoints.
+
+These wrap the same underlying signal as `getRecentPrioritizationFees` with better filtering and freshness. Use the baseline when you want zero dependencies or are on a generic RPC; use a provider API when you're already on that provider.
+
+## Fee math (so you can reason about cost)
+
+```
+priorityFeeLamports = ceil( microLamports × computeUnitLimit / 1_000_000 )
+totalFeeLamports     = 5_000 (base, per signature) + priorityFeeLamports
+```
+
+Worked example — 50,000 CU at 75,000 microLamports/CU:
+```
+priority = 75_000 × 50_000 / 1_000_000 = 3_750 lamports
+total    = 5_000 + 3_750 = 8_750 lamports ≈ 0.00000875 SOL
+```
+
+This is why [right-sizing the CU limit](compute-units.md) matters as much as the price: the fee is the product of the two. Halving an oversized limit halves the priority fee at the same price.
+
+## Refresh frequency
+
+| Workload | Refresh |
+|----------|---------|
+| Ordinary app | every 10–20 seconds |
+| Trading / swaps | per transaction |
+| HFT / MEV | every slot |
+
+## Common mistakes
+
+- **Hardcoding the fee** — guarantees you over- or under-pay; under-paying drops the transaction.
+- **Estimating without `lockedWritableAccounts`** — underprices hot-account contention.
+- **Pricing high but leaving the default CU limit** — you pay the high price across 200k CUs you don't use.
+- **No buffer** — the estimate is historical; congestion can rise between estimate and submission.
+- **Defaulting to `unsafeMax`/0.9+** — can cost 10–100× normal; reserve for genuinely competitive slots.

--- a/skills/transaction-landing/resources/constants.md
+++ b/skills/transaction-landing/resources/constants.md
@@ -1,0 +1,71 @@
+# Constants & Endpoints
+
+## Compute budget
+
+| Constant | Value |
+|----------|-------|
+| Base fee | 5,000 lamports per signature |
+| Default CU limit (unset) | `200,000 × num_instructions`, capped at 1,400,000 |
+| Max CU limit | 1,400,000 |
+| Compute-budget program | `ComputeBudget111111111111111111111111111111` |
+| `setComputeUnitLimit` units | `u32` (CUs) |
+| `setComputeUnitPrice` microLamports | `u64` (microLamports per CU) |
+
+Fee formula: `priorityLamports = ceil(microLamports × cuLimit / 1_000_000)`.
+
+## Priority-fee estimation
+
+| Source | How |
+|--------|-----|
+| `getRecentPrioritizationFees` | Standard RPC method; pass `lockedWritableAccounts`. Provider-agnostic baseline. |
+| Helius `getPriorityFeeEstimate` | `https://mainnet.helius-rpc.com/?api-key=...`; see the [`helius`](../../helius/) skill |
+| QuickNode `qn_estimatePriorityFees` | See the [`quicknode`](../../quicknode/) skill |
+
+## Blockhash / confirmation
+
+| Item | Value |
+|------|-------|
+| Blockhash validity | ~150 slots (~60–90s) |
+| Expiry signal | `currentBlockHeight > lastValidBlockHeight` |
+| Commitments | `processed` < `confirmed` < `finalized` |
+| Status method | `getSignatureStatuses([sig], { searchTransactionHistory })` |
+
+## Jito (rung 3)
+
+**Tip accounts — fetch at runtime, never hardcode.** The set rotates; a stale or wrong address silently burns your tip. Use the Block Engine `getTipAccounts` JSON-RPC method (see [examples/jito-bundle.ts](../examples/jito-bundle.ts)). For Helius Sender's tip-account list specifically, the in-repo [`helius`](../../helius/) skill (`references/sender.md`) carries a verified set.
+
+| Resource | Endpoint |
+|----------|----------|
+| Tip accounts (live) | `getTipAccounts` on any Block Engine URL below |
+| Tip floor API | `https://bundles.jito.wtf/api/v1/bundles/tip_floor` (use `landed_tips_75th_percentile`) |
+| Block Engine (global) | `https://mainnet.block-engine.jito.wtf/api/v1/bundles` |
+| Block Engine (Amsterdam) | `https://amsterdam.mainnet.block-engine.jito.wtf/api/v1/bundles` |
+| Block Engine (Frankfurt) | `https://frankfurt.mainnet.block-engine.jito.wtf/api/v1/bundles` |
+| Block Engine (NY) | `https://ny.mainnet.block-engine.jito.wtf/api/v1/bundles` |
+| Block Engine (Tokyo) | `https://tokyo.mainnet.block-engine.jito.wtf/api/v1/bundles` |
+| Block Engine (devnet) | `https://dallas.devnet.block-engine.jito.wtf/api/v1/bundles` |
+| Bundle methods | `sendBundle`, `getBundleStatuses`, `getTipAccounts` |
+
+Bundle limits: **max 5 transactions**, all-or-nothing, single slot. Minimum tip to land in practice: ~0.0001 SOL (size dynamically from the tip floor).
+
+## Error strings → meaning
+
+| String (substring match) | Meaning | Treat as |
+|--------------------------|---------|----------|
+| `already been processed` | The transaction already landed | **Success** |
+| `Blockhash not found` | Blockhash not yet known to this node, or expired | Retry send; if persistent, rebuild |
+| `block height exceeded` / `TransactionExpiredBlockheightExceededError` | Lifetime expired | Rebuild (after verifying it didn't land) |
+| `insufficient funds for fee` / `insufficient lamports` | Payer can't cover fee/rent | Fund payer; lower fee |
+| `exceeded CUs` / `ComputeBudgetExceeded` | CU limit too low | Raise limit via simulation |
+| `Node is behind` / `-32005` | RPC lagging | Switch RPC / retry |
+| `429` / rate limit | Too many requests | Back off, rotate endpoint |
+
+## Cluster RPCs
+
+| Cluster | URL |
+|---------|-----|
+| Devnet | `https://api.devnet.solana.com` |
+| Testnet | `https://api.testnet.solana.com` |
+| Mainnet (public, rate-limited) | `https://api.mainnet-beta.solana.com` |
+
+Public mainnet RPC is fine for reads and devnet work; use a staked provider ([`helius`](../../helius/) / [`quicknode`](../../quicknode/)) for production sending.


### PR DESCRIPTION
## Summary

Adds a **`transaction-landing`** skill — a provider-agnostic guide to getting Solana transactions confirmed reliably without overpaying or double-executing. This is the most common production failure on Solana (dropped transactions under congestion), and the existing `helius`/`quicknode` skills cover it only from their own provider's angle. This skill is the universal layer underneath them and routes to them for accelerated sending.

## What it covers

The "five decisions" that determine whether a transaction lands:

1. **Right-size compute units** — simulation-based CU estimation, never the default 200k
2. **Price the priority fee** — `getRecentPrioritizationFees` baseline (+ provider APIs), percentile strategy, fee math
3. **Choose a lifetime** — recent blockhash vs durable nonce
4. **Submit + rebroadcast** — resend the *same* signed bytes, idempotent by signature
5. **Confirm correctly** — poll status against `lastValidBlockHeight`, stop at expiry

Plus a **reliability ladder** (public RPC → right-sized+rebroadcast → staked/SWQOS routing → Jito bundles) and an **Agentic Safety** section: the idempotency invariants that stop autonomous agents from double-spending on retry (rebroadcast identical bytes vs re-signing a fresh transaction; verify on-chain state before rebuilding; `already processed` == success).

## Structure

- `SKILL.md` — five decisions, reliability ladder, agentic safety
- `references/` — compute-units, priority-fees, confirmation (rebroadcast loop, durable nonces, safe-retry), escalation (staked routing + Jito bundles)
- `examples/` — two runnable TS files: full send-and-confirm with safe-retry, and a Jito bundle (tip accounts fetched live via `getTipAccounts`, never hardcoded)
- `resources/constants.md` — error-string catalog, endpoints, compute-budget reference
- `docs/troubleshooting.md` — error → cause → fix

## Checklist

- [x] Follows the template structure (SKILL.md + references/examples/resources/docs)
- [x] Frontmatter with routing-friendly `description`
- [x] Working, self-contained examples with error handling and real addresses/methods
- [x] Security/idempotency considerations (the agentic-safety section)
- [x] Devnet vs mainnet differences called out
- [x] Added entry to `.claude-plugin/marketplace.json` (category: Infrastructure) — `node scripts/validate-marketplace.js` passes
- [x] Routes to existing `helius`/`quicknode` skills rather than duplicating them

🤖 Generated with [Claude Code](https://claude.com/claude-code)
