### PR TITLE
Add Flutter and Dart Solana skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -22,6 +22,12 @@
       "category": "Data & Analytics"
     },
     {
+      "name": "building-solana-transactions-flutter",
+      "source": "./skills/building-solana-transactions-flutter",
+      "description": "Build, sign, simulate, and send Solana transactions in Dart and Flutter with the solana SDK and coral_xyz. Compile legacy or V0 messages, add priority fees, and diagnose simulation and TransactionError failures.",
+      "category": "Client Development"
+    },
+    {
       "name": "carbium",
       "source": "./skills/carbium",
       "description": "Full-stack Solana infrastructure — bare-metal RPC, Standard WebSocket pubsub, gRPC Full Block streaming, DEX aggregation via CQ1 engine, gasless swaps, and MEV-protected execution via Jito bundling",
@@ -32,6 +38,12 @@
       "source": "./skills/coingecko",
       "description": "CoinGecko Solana API for token prices, DEX pool data, OHLCV charts, trades, and market analytics",
       "category": "Data & Analytics"
+    },
+    {
+      "name": "coral-xyz-anchor-dart",
+      "source": "./skills/coral-xyz-anchor-dart",
+      "description": "Typed Dart clients for Solana programs with coral_xyz, the Dart equivalent of @coral-xyz/anchor. Load an IDL to call instructions, fetch accounts, derive PDAs, and subscribe to events without manual Borsh.",
+      "category": "Client Development"
     },
     {
       "name": "ct-alpha",
@@ -50,6 +62,30 @@
       "source": "./skills/dflow",
       "description": "DFlow trading protocol for spot trading, prediction markets, Swap API, and WebSocket streaming",
       "category": "Trading"
+    },
+    {
+      "name": "flutter-solana-domain-resolution",
+      "source": "./skills/flutter-solana-domain-resolution",
+      "description": "Resolve Solana domains in Flutter and Dart with tld_parser for the AllDomains ANS, covering every custom TLD like .skr, .bonk, and .backpack. Forward and reverse lookup, records, avatars, user domains, and batch resolution. ANS is separate from Bonfida SNS (.sol).",
+      "category": "Infrastructure"
+    },
+    {
+      "name": "flutter-solana-metaplex-nft",
+      "source": "./skills/flutter-solana-metaplex-nft",
+      "description": "Mint and read Solana NFTs in Flutter and Dart with Metaplex Token Metadata via package:solana/metaplex.dart. Create a 0-decimal mint plus master edition, parse on-chain and off-chain metadata, and run a backend-mediated MWA-signed mint.",
+      "category": "NFT & Tokens"
+    },
+    {
+      "name": "flutter-solana-wallet-security",
+      "source": "./skills/flutter-solana-wallet-security",
+      "description": "Harden Solana wallets and dApps in Flutter and Dart. Encrypt keys at rest, gate actions with biometrics, hash PINs with salted Argon2id, manage secrets, and simulate before sending.",
+      "category": "Security"
+    },
+    {
+      "name": "flutter-solana-zk-compression",
+      "source": "./skills/flutter-solana-zk-compression",
+      "description": "Compress, transfer, and decompress SOL and SPL tokens in Flutter with light_sdk and Light Protocol ZK compression. Compressed accounts and tokens, Groth16 validity proofs from the Photon indexer over Helius, and mobile external-wallet signing.",
+      "category": "Infrastructure"
     },
     {
       "name": "glam",
@@ -74,6 +110,12 @@
       "source": "./skills/helius-phantom",
       "description": "Build frontend Solana applications with Phantom Connect SDK and Helius infrastructure for wallet connection, transaction signing, and secure API proxying",
       "category": "Frontend"
+    },
+    {
+      "name": "integrating-jupiter-flutter",
+      "source": "./skills/integrating-jupiter-flutter",
+      "description": "Quote and execute Solana token swaps in Flutter and Dart with the Jupiter aggregator and the jupiter_aggregator Dio client. Multi-hop routes, slippage tiers, price-impact guards, Price API, and signing swaps with MWA or a local keypair.",
+      "category": "DeFi"
     },
     {
       "name": "jupiter",
@@ -226,6 +268,12 @@
       "category": "AI Agents"
     },
     {
+      "name": "solana-dart-sdk",
+      "source": "./skills/solana-dart-sdk",
+      "description": "Build Solana apps in Dart and Flutter with the solana package. RPC calls, mnemonic keypairs, PDAs and ATAs, transaction building, ByteArray instruction data, priority fees, and WebSocket subscriptions.",
+      "category": "Client Development"
+    },
+    {
       "name": "solana-kit",
       "source": "./skills/solana-kit",
       "description": "Modern tree-shakeable JavaScript SDK from Anza with zero dependencies and full TypeScript support",
@@ -236,6 +284,18 @@
       "source": "./skills/solana-kit-migration",
       "description": "Migration guide between @solana/web3.js v1.x and @solana/kit with API mappings",
       "category": "Client Development"
+    },
+    {
+      "name": "solana-mobile-wallet-adapter-flutter",
+      "source": "./skills/solana-mobile-wallet-adapter-flutter",
+      "description": "Connect Flutter Android dApps to Solana wallets with the Mobile Wallet Adapter protocol. MWA sessions, authorize and reauthorize, sign and send transactions, and persist auth tokens. Android only.",
+      "category": "Client Development"
+    },
+    {
+      "name": "spl-token-dart",
+      "source": "./skills/spl-token-dart",
+      "description": "SPL Token and Token-2022 flows in Flutter and Dart with the solana package. Create mints and ATAs, mint, transfer, burn, manage authorities, and read parsed balances.",
+      "category": "NFT & Tokens"
     },
     {
       "name": "svm",

--- a/skills/building-solana-transactions-flutter/SKILL.md
+++ b/skills/building-solana-transactions-flutter/SKILL.md
@@ -1,0 +1,393 @@
+---
+name: building-solana-transactions-flutter
+description: Build, sign, simulate, and send Solana transactions in Dart and Flutter with the solana SDK and coral_xyz. Use to compile legacy or V0 messages, order signers, add compute-budget priority fees, simulate before sending, and diagnose "failed to simulate transaction" errors from JsonRpcException and TransactionError. Cross-platform Dart.
+license: MIT
+metadata:
+  author: Dominion Nwakanma (web3flutter.dev)
+  version: "1.0.0"
+tags:
+  - solana
+  - transactions
+  - flutter
+  - dart
+  - coral-xyz
+  - simulation
+  - priority-fees
+  - compute-budget
+  - signing
+---
+
+# Building Solana Transactions in Dart and Flutter
+
+## Overview
+
+Every Solana transaction in Dart follows the same lifecycle: build instructions into a `Message`, fetch a recent blockhash, compile the message (legacy or V0), sign with all required keypairs, simulate (optional but recommended), then send and confirm.
+
+The `solana` package gives you low-level control at every step. The `coral_xyz` package wraps an Anchor program in a fluent builder that runs the full lifecycle for you.
+
+Two failures dominate real apps. Blockhashes expire in about 60 seconds, so a stale one breaks sends. And "failed to simulate transaction" is a generic wrapper: the real cause sits inside the `TransactionError`. This skill covers both, plus priority fees, which you need for reliable landing during congestion.
+
+Pin `solana` at 0.31.2 or higher. If you add the `coral_xyz` builder, pin `solana` at ^0.32.0, because coral_xyz beta.9 depends on solana ^0.32.0. Expect minor API drift on both.
+
+## Instructions
+
+1. Add `solana: ^0.31.2` to pubspec.yaml. Add `coral_xyz` only if you are calling an Anchor program through a typed builder, and in that case pin `solana: ^0.32.0` to satisfy coral_xyz beta.9.
+2. Build your instructions, then compose them into a `Message`. Use `Message.only(ix)` for a single instruction or `Message(instructions: [ix1, ix2])` for several.
+3. Fetch a fresh blockhash with `getLatestBlockhash` immediately before you sign. Never cache it across transactions.
+4. Compile with `message.compile` for legacy or `message.compileV0` when you need address lookup tables.
+5. Put the fee payer first in the signers list. The signature order must match the signer-account order in the compiled message.
+6. Sign with `signTransaction` (legacy) or `signV0Transaction` (V0). Both throw `FormatException` if the signer count does not match the required count.
+7. Simulate with `simulateTransaction` before sending. Pick either `sigVerify` or `replaceRecentBlockhash`, never both.
+8. Prepend `ComputeBudgetInstruction.setComputeUnitLimit` and `setComputeUnitPrice` so the transaction lands during congestion.
+9. Send. For the simplest path use `client.sendAndConfirmTransaction`. For manual control use `rpcClient.sendTransaction`, and match `preflightCommitment` to the commitment you used when creating the accounts.
+10. Wrap sends in a `try`/`catch` for `JsonRpcException`. Read `e.transactionError` and `e.data` to find the real cause.
+
+## Examples
+
+### Quick start: send SOL end to end
+
+The high-level path. `sendAndConfirmTransaction` fetches the blockhash, compiles, signs, sends, and waits for confirmation in one call.
+
+```dart
+import 'package:solana/solana.dart';
+
+Future<String> sendSol({
+  required SolanaClient client,
+  required Ed25519HDKeyPair sender,
+  required Ed25519HDPublicKey recipient,
+  required int lamports,
+}) async {
+  final instruction = SystemInstruction.transfer(
+    fundingAccount: sender.publicKey,
+    recipientAccount: recipient,
+    lamports: lamports,
+  );
+
+  return client.sendAndConfirmTransaction(
+    message: Message.only(instruction),
+    signers: [sender],
+    onSigned: ignoreOnSigned,
+    commitment: Commitment.confirmed,
+  );
+}
+```
+
+### Manual control: compile, sign, simulate, send
+
+When you need to inspect the compiled bytes, simulate explicitly, or branch on the result. The fee payer is first in the signers list.
+
+```dart
+import 'package:solana/solana.dart';
+
+Future<String?> sendManually({
+  required RpcClient rpcClient,
+  required Ed25519HDKeyPair signer,
+  required Message message,
+}) async {
+  // 1. Fetch the blockhash right before signing.
+  final bh = await rpcClient
+      .getLatestBlockhash(commitment: Commitment.confirmed)
+      .then((r) => r.value);
+
+  // 2. Compile and sign. Fee payer signs the compiled bytes.
+  final compiled = message.compile(
+    recentBlockhash: bh.blockhash,
+    feePayer: signer.publicKey,
+  );
+  final signatures = await Future.wait(
+    [signer].map((s) => s.sign(compiled.toByteArray())),
+  );
+  final signedTx = SignedTx(
+    compiledMessage: compiled,
+    signatures: signatures,
+  );
+
+  // 3. Simulate first. Bail out if it fails.
+  final sim = await rpcClient.simulateTransaction(
+    signedTx.encode(),
+    commitment: Commitment.confirmed,
+  );
+  if (sim.value.err != null) {
+    print('Simulation failed: ${sim.value.err}');
+    print('Logs: ${sim.value.logs}');
+    return null;
+  }
+
+  // 4. Send. Match preflight to your account-creation commitment.
+  return rpcClient.sendTransaction(
+    signedTx.encode(),
+    preflightCommitment: Commitment.confirmed,
+  );
+}
+```
+
+### Legacy and V0 signing helpers
+
+`signTransaction` and `signV0Transaction` validate that the signer count equals the required count and throw `FormatException` on a mismatch. The fee payer must be the first signer.
+
+```dart
+import 'package:solana/solana.dart';
+
+Future<SignedTx> signLegacy({
+  required LatestBlockhash latestBlockhash,
+  required Message message,
+  required Ed25519HDKeyPair feePayer,
+  required Ed25519HDKeyPair otherSigner,
+}) {
+  // Fee payer first, additional signers after.
+  return signTransaction(latestBlockhash, message, [feePayer, otherSigner]);
+}
+
+Future<SignedTx> signV0({
+  required LatestBlockhash recentBlockhash,
+  required Message message,
+  required Ed25519HDKeyPair signer,
+  required AddressLookupTableAccount lookupTable,
+}) {
+  return signV0Transaction(
+    recentBlockhash,
+    message,
+    [signer],
+    addressLookupTableAccounts: [lookupTable],
+  );
+}
+```
+
+### Simulate with explicit flags
+
+`sigVerify` and `replaceRecentBlockhash` are mutually exclusive. Use `replaceRecentBlockhash: true` to let the node supply a fresh blockhash when the transaction is not properly signed yet.
+
+```dart
+import 'package:solana/solana.dart';
+
+Future<bool> simulate({
+  required RpcClient rpcClient,
+  required SignedTx signedTx,
+}) async {
+  final result = await rpcClient.simulateTransaction(
+    signedTx.encode(),
+    sigVerify: false,             // Skip signature verification.
+    commitment: Commitment.confirmed,
+    replaceRecentBlockhash: true, // Use the node's blockhash. Cannot combine with sigVerify.
+  );
+
+  print('Error: ${result.value.err}');          // TransactionError?, null means success.
+  print('Logs: ${result.value.logs}');          // List<String> of program logs.
+  print('Units: ${result.value.unitsConsumed}'); // Compute units used.
+  return result.value.err == null;
+}
+```
+
+### Priority fees with a multi-instruction transaction
+
+Prepend the compute budget instructions so they run first. Then create the destination ATA if it is missing, transfer, and attach a memo.
+
+```dart
+import 'package:solana/solana.dart';
+
+Future<String> payWithPriorityFee({
+  required SolanaClient client,
+  required Ed25519HDKeyPair wallet,
+  required Ed25519HDPublicKey recipient,
+  required Ed25519HDPublicKey senderAta,
+  required Ed25519HDPublicKey ataPubKey,
+  required Ed25519HDPublicKey mintPubKey,
+}) {
+  final message = Message(instructions: [
+    // Priority fee instructions run first.
+    ComputeBudgetInstruction.setComputeUnitLimit(units: 200000),
+    ComputeBudgetInstruction.setComputeUnitPrice(microLamports: 5000),
+
+    // Create the recipient ATA.
+    AssociatedTokenAccountInstruction.createAccount(
+      funder: wallet.publicKey,
+      address: ataPubKey,
+      owner: recipient,
+      mint: mintPubKey,
+    ),
+
+    // Transfer tokens.
+    TokenInstruction.transfer(
+      source: senderAta,
+      destination: ataPubKey,
+      owner: wallet.publicKey,
+      amount: 1000000,
+    ),
+
+    // Optional memo.
+    MemoInstruction(signers: [wallet.publicKey], memo: 'Payment'),
+  ]);
+
+  return client.sendAndConfirmTransaction(
+    message: message,
+    signers: [wallet],
+    onSigned: ignoreOnSigned,
+    commitment: Commitment.confirmed,
+  );
+}
+```
+
+### Retry with a fresh blockhash
+
+`sendAndConfirmTransaction` fetches a new blockhash on each call, so a retry on `blockhashNotFound` picks up a fresh one automatically.
+
+```dart
+import 'package:solana/solana.dart';
+
+Future<String> sendWithRetry({
+  required SolanaClient client,
+  required Message message,
+  required List<Ed25519HDKeyPair> signers,
+  int maxAttempts = 3,
+}) async {
+  for (var i = 0; i < maxAttempts; i++) {
+    try {
+      return await client.sendAndConfirmTransaction(
+        message: message,
+        signers: signers,
+        onSigned: ignoreOnSigned,
+        commitment: Commitment.confirmed,
+      );
+    } on JsonRpcException catch (e) {
+      if (e.transactionError == TransactionError.blockhashNotFound &&
+          i < maxAttempts - 1) {
+        continue; // Retry. sendAndConfirmTransaction fetches a fresh blockhash.
+      }
+      rethrow;
+    }
+  }
+  throw Exception('Max retry attempts exceeded');
+}
+```
+
+### coral_xyz typed builder
+
+`TypeSafeMethodBuilder` exposes five terminal operations. Use `.rpc()` to sign, send, and confirm, or `.simulate()` to dry-run without sending.
+
+```dart
+import 'package:coral_xyz/coral_xyz.dart';
+
+Future<String> callProgram({
+  required Program program,
+  required int arg1,
+  required int arg2,
+  required PublicKey account1,
+  required PublicKey account2,
+  required Keypair signer,
+}) async {
+  final builder = program.methods
+      .myInstruction([arg1, arg2])
+      .accounts({'account1': account1, 'account2': account2})
+      .signers([signer]);
+
+  // Terminal operations:
+  // builder.instruction() -> just the instruction
+  // builder.transaction()  -> unsigned transaction
+  // builder.simulate()     -> simulate without sending
+  // builder.view()         -> simulate and decode return data
+  // builder.rpc()          -> sign, send, confirm (most common)
+  return builder.rpc();
+}
+```
+
+### Diagnose a failed send
+
+The "failed to simulate transaction" error surfaces as `JsonRpcException` with code `-32002`. The real cause is in `transactionError`, and the program logs are in `data`.
+
+```dart
+import 'package:solana/solana.dart';
+
+Future<void> sendAndDiagnose({
+  required SolanaClient client,
+  required Message message,
+  required List<Ed25519HDKeyPair> signers,
+}) async {
+  try {
+    await client.sendAndConfirmTransaction(
+      message: message,
+      signers: signers,
+      onSigned: ignoreOnSigned,
+      commitment: Commitment.confirmed,
+    );
+  } on JsonRpcException catch (e) {
+    print('RPC error code: ${e.code}');
+    print('Message: ${e.message}');
+    print('Transaction error: ${e.transactionError}');
+    print('Data (contains logs): ${e.data}');
+    rethrow;
+  }
+}
+```
+
+## Guidelines
+
+- DO fetch a fresh blockhash immediately before signing. They expire in about 60 seconds, so never cache one across transactions.
+- DO put the fee payer first in the signers list. The first signer is always the fee payer.
+- DO simulate before sending so you catch failures cheaply, and read `result.value.logs` when `err` is non-null.
+- DO match `preflightCommitment` to the commitment you used to create the accounts. If you created them with `confirmed`, send with `confirmed`.
+- DO prepend `ComputeBudgetInstruction.setComputeUnitPrice` so the transaction lands during congestion.
+- DO check and create the ATA before a token transfer. Use `hasAssociatedTokenAccount`, then `createAssociatedTokenAccount`.
+- DON'T combine `sigVerify: true` with `replaceRecentBlockhash: true`. They are mutually exclusive.
+- DON'T use `skipPreflight: true` to hide simulation errors. It only delays the failure to landing time.
+- DON'T ignore `JsonRpcException.data`. It carries the program logs that explain the failure.
+- DON'T resend a transaction blindly after `alreadyProcessed`. Check `getSignatureStatuses` first.
+
+## Common Errors
+
+The most common failure is "failed to simulate transaction", which arrives as a `JsonRpcException` with code `-32002`. Read the `transactionError` field to find the actual `TransactionError`. This table maps each value to its cause and fix.
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `programAccountNotFound` | Program not deployed on the target cluster | Verify the program ID exists on the RPC cluster (devnet vs mainnet) |
+| `blockhashNotFound` | Blockhash expired (older than about 60 seconds) | Fetch a fresh blockhash immediately before signing |
+| `insufficientFundsForFee` | Fee payer has too little SOL | Fund the fee payer (about 0.000005 SOL per signature) |
+| `instructionError` | A program rejected the instruction | Read the logs. Common causes are a PDA mismatch, wrong seeds, or a constraint violation |
+| `signatureFailure` | Wrong or missing signatures | Confirm every required signer is in the signers list |
+| `missingSignatureForFee` | Fee payer did not sign | Put the fee payer first in the signers list |
+| `accountNotFound` | A referenced account does not exist | Create the account first, for example the ATA for token transfers |
+| `alreadyProcessed` | Duplicate transaction | The tx already landed. Check `getSignatureStatuses` before retrying |
+| `FormatException` on signing | Signer count does not match the required count | Provide exactly the required signers, fee payer first |
+| `NoAssociatedTokenAccountException` | Destination ATA is missing | Create the ATA before building the token transfer instruction |
+| `JsonRpcException` after `confirmed` account creation | `preflightCommitment` defaults to `finalized`, which cannot see the new accounts yet | Pass `preflightCommitment: Commitment.confirmed` to match the creation commitment |
+
+## Compute Budget and Priority Fees
+
+Prepend compute budget instructions to every transaction for reliable landing. These four instructions control the budget.
+
+| Instruction | Purpose |
+|-------------|---------|
+| `setComputeUnitLimit(units:)` | Max compute units for the transaction (default is 200k per instruction) |
+| `setComputeUnitPrice(microLamports:)` | Priority fee per compute unit. Higher lands faster |
+| `requestHeapFrame(bytes:)` | Increase the heap from 32KB (max 256KB) |
+| `setLoadedAccountsDataSizeLimit(bytes:)` | Cap the loaded account data size |
+
+Pick a priority fee from current network conditions.
+
+| Scenario | microLamports |
+|----------|---------------|
+| Low congestion | 1 to 100 |
+| Normal | 1,000 to 10,000 |
+| High demand or time-sensitive | 50,000 to 500,000 |
+| MEV-prone swaps | 100,000 to 1,000,000 |
+
+## Commitment Levels
+
+```dart
+enum Commitment { processed, confirmed, finalized }
+```
+
+| Level | Speed | Safety | Use when |
+|-------|-------|--------|----------|
+| `processed` | about 400ms | May be dropped | Never for sends. Not supported by `sendAndConfirmTransaction` |
+| `confirmed` | about 5s | Supermajority voted | Default for interactive UX |
+| `finalized` | about 30s | Rooted and irreversible | Financial operations and large transfers |
+
+`sendTransaction` defaults `preflightCommitment` to `finalized`, so simulation runs against finalized state. If your accounts were just created with `confirmed`, simulation can fail because the finalized state does not see them yet. Pass `preflightCommitment: Commitment.confirmed` to fix this.
+
+## References
+
+- solana Dart SDK: https://pub.dev/packages/solana
+- coral_xyz (Anchor client for Dart): https://pub.dev/packages/coral_xyz
+- Solana transaction docs: https://solana.com/docs/core/transactions
+- Compute budget and priority fees: https://solana.com/developers/guides/advanced/how-to-use-priority-fees
+- Related skills in this set: solana-dart-sdk, solana-mobile-wallet-adapter-flutter, flutter-solana-wallet-security

--- a/skills/coral-xyz-anchor-dart/SKILL.md
+++ b/skills/coral-xyz-anchor-dart/SKILL.md
@@ -1,0 +1,332 @@
+---
+name: coral-xyz-anchor-dart
+description: Build typed Dart clients for Solana programs with the coral_xyz package, the Dart equivalent of @coral-xyz/anchor. Load an IDL and integrate Anchor, Quasar, or Pinocchio programs in Flutter. Use to call instructions, fetch and decode accounts, derive PDAs, subscribe to events, and simulate transactions without manual Borsh wiring.
+license: MIT
+metadata:
+  author: Dominion Nwakanma (web3flutter.dev)
+  version: "1.0.0"
+tags:
+  - solana
+  - anchor
+  - coral-xyz
+  - flutter
+  - dart
+  - idl
+  - pda
+  - program-client
+  - borsh
+---
+
+# coral_xyz Anchor Client for Dart
+
+## Overview
+
+`coral_xyz` is the Dart equivalent of `@coral-xyz/anchor` from the TypeScript ecosystem. You give it a program's IDL (JSON) and it gives you a `Program` object with full namespace access: call instructions, fetch and decode accounts, subscribe to events, derive PDAs, and simulate transactions, all without writing manual Borsh serialization.
+
+It supports three Solana program frameworks. Anchor uses SHA256 8-byte discriminators, Borsh-encoded accounts, and the standard Anchor IDL format. Quasar uses explicit N-byte discriminators, zero-copy `#[repr(C)]` accounts, and bounded strings and vecs. Pinocchio and manual programs define their interface through the `ProgramInterface` builder with raw byte layouts.
+
+The IDL format is auto-detected. You do not choose. Pass any IDL JSON and `coral_xyz` figures out the framework and selects the right coder.
+
+This package is pre-1.0 (v1.0.0-beta.9 at time of writing), so pin the version and expect minor API drift between betas.
+
+## Instructions
+
+1. Add `coral_xyz: ^1.0.0-beta.9` and `solana: ^0.32.0` to pubspec.yaml. coral_xyz beta.9 depends on solana ^0.32.0, so pin solana there, not on 0.31.x, or the resolve fails.
+2. Load the IDL JSON from a file, asset bundle, or network, then parse it with `Idl.fromJson(jsonDecode(idlString) as Map<String, dynamic>)`.
+3. If the IDL JSON has no `address` field, inject it (`idlMap['address'] = programId;`) before parsing, or build the program with `Program.withProgramId()`.
+4. Create a `Connection` and a `Wallet`, then wrap them in an `AnchorProvider`. Use `AnchorProvider.readOnly(connection)` only for reads. Use `AnchorProvider(connection, wallet)` for writes.
+5. Build the program with `Program(idl, provider: provider)`, `Program.withProgramId(idl, publicKey, provider: provider)`, or `Program.at(address, provider: provider)`.
+6. Call instructions through the `methods` namespace. In Flutter, cast to `dynamic` so the `noSuchMethod` dispatch can route IDL method names: `(program.methods as dynamic).initialize().accounts({'config': configPda}).rpc()`.
+7. Fetch accounts through `program.account['Name']!.fetch(pda)`. Account data comes back as `Map<String, dynamic>`. Decode u64 and i64 fields as `BigInt`.
+8. Derive PDAs with `PublicKeyUtils.findProgramAddress(seeds, programId)` using the deployed program ID, not the hardcoded test ID from Rust source.
+9. Call `await program.dispose()` when you are done to tear down event subscriptions and connections.
+
+## Examples
+
+### Quick start: load IDL, call an instruction, fetch an account
+
+```dart
+import 'dart:convert';
+import 'package:coral_xyz/coral_xyz.dart';
+
+Future<int> quickStart() async {
+  // 1. Load IDL from JSON (file, asset bundle, or network).
+  final idlJson =
+      '{"address":"A9yYAEQ1sCfZbR5o","instructions":[],"accounts":[]}';
+  final idlMap = jsonDecode(idlJson) as Map<String, dynamic>;
+  final idl = Idl.fromJson(idlMap);
+
+  // 2. Set up the provider.
+  final connection = Connection('https://api.devnet.solana.com');
+  final wallet = await KeypairWallet.generate();
+  final provider = AnchorProvider(connection, wallet);
+
+  // 3. Create the program.
+  final program = Program(idl, provider: provider);
+
+  // 4. Derive the PDA the instruction needs.
+  final counterPda = (await PublicKeyUtils.findProgramAddress(
+    [utf8.encode('counter')],
+    program.programId,
+  )).address;
+
+  // 5. Call an instruction.
+  await (program.methods as dynamic)
+      .initialize()
+      .accounts({
+        'counter': counterPda,
+        'payer': wallet.publicKey,
+        'systemProgram': PublicKeyUtils.systemProgram,
+      })
+      .rpc();
+
+  // 6. Fetch and decode an account. u64 fields come back as BigInt.
+  final data = await program.account['Counter']!.fetch(counterPda);
+  return (data['count'] as BigInt).toInt();
+}
+```
+
+### Flutter service: read-only first, upgrade to a write provider on wallet connect
+
+This is the common Flutter shape. Fetch accounts before the wallet connects, then rebuild the program with a full provider once it does.
+
+```dart
+import 'dart:convert';
+import 'package:flutter/services.dart';
+import 'package:coral_xyz/coral_xyz.dart';
+
+class SolanaService {
+  static const String _programId = 'A9yYAEQ1sCfZbR5o';
+  static const String _rpcUrl = 'https://api.devnet.solana.com';
+
+  Program? _program;
+  PublicKey? _counterPda;
+
+  // 1. Initialize read-only (fetch accounts before wallet connect).
+  Future<void> initReadOnly() async {
+    final idlString = await rootBundle.loadString('assets/idl.json');
+    final idlMap = jsonDecode(idlString) as Map<String, dynamic>;
+    idlMap['address'] = _programId; // inject if IDL JSON lacks it
+
+    final idl = Idl.fromJson(idlMap);
+    final connection = Connection(_rpcUrl);
+
+    _program = Program.withProgramId(
+      idl,
+      PublicKeyUtils.fromBase58(_programId),
+      provider: AnchorProvider.readOnly(connection),
+    );
+  }
+
+  // 2. Upgrade to a full provider when the wallet connects.
+  void connectWallet(Wallet wallet) {
+    _program = Program.withProgramId(
+      _program!.idl,
+      _program!.programId,
+      provider: AnchorProvider(Connection(_rpcUrl), wallet),
+    );
+  }
+
+  // 3. Derive the PDA once and cache it.
+  Future<PublicKey> getCounterPda() async {
+    _counterPda ??= (await PublicKeyUtils.findProgramAddress(
+      [utf8.encode('counter_v2')],
+      _program!.programId,
+    )).address;
+    return _counterPda!;
+  }
+
+  // 4. Write: initialize.
+  Future<String> initialize() async {
+    final pda = await getCounterPda();
+    return await ((_program!.methods as dynamic)
+        .initialize()
+        .accounts({
+          'counter': pda,
+          'payer': _program!.provider.wallet!.publicKey,
+          'systemProgram': PublicKeyUtils.systemProgram,
+        })
+        .rpc()) as String;
+  }
+
+  // 5. Write: increment.
+  Future<String> increment(int amount) async {
+    final pda = await getCounterPda();
+    return await ((_program!.methods as dynamic)
+        .increment(BigInt.from(amount))
+        .accounts({'counter': pda})
+        .rpc()) as String;
+  }
+
+  // 6. Read: fetch the count. u64 decodes to BigInt.
+  Future<int> getCount() async {
+    final pda = await getCounterPda();
+    final data = await _program!.account['Counter']!.fetch(pda);
+    return (data['count'] as BigInt).toInt();
+  }
+
+  // 7. Cleanup.
+  Future<void> dispose() async {
+    await _program?.dispose();
+  }
+}
+```
+
+### Full fluent builder, then a terminal call
+
+Every method access returns a `TypeSafeMethodBuilder`. Chain the modifiers, then pick one terminal.
+
+```dart
+import 'package:coral_xyz/coral_xyz.dart';
+
+Future<String> transferWithBuilder({
+  required Program program,
+  required PublicKey fromPda,
+  required PublicKey toPda,
+  required PublicKey authority,
+  required PublicKey customTokenProgram,
+  required PublicKey extraAccount,
+  required Wallet extraKeypair,
+  required TransactionInstruction computeBudgetIx,
+  required TransactionInstruction memoIx,
+}) async {
+  final builder = program.methods['transfer']!([BigInt.from(1000000)])
+      .accounts({
+        'from': fromPda,
+        'to': toPda,
+        'authority': authority,
+      })
+      .accountsPartial({                 // override only some accounts
+        'tokenProgram': customTokenProgram,
+      })
+      .signers([extraKeypair])           // signers beyond the wallet
+      .remainingAccounts([               // extra accounts not in the IDL
+        AccountMeta(
+          publicKey: extraAccount,
+          isWritable: true,
+          isSigner: false,
+        ),
+      ])
+      .preInstructions([computeBudgetIx])
+      .postInstructions([memoIx]);
+
+  // Terminal: send and return the signature.
+  return await builder.rpc();
+}
+```
+
+Other terminals on the same builder: `builder.instruction()` returns a `TransactionInstruction`, `builder.transaction()` returns an `AnchorTransaction`, `builder.simulate()` returns a `SimulationResult` (with `success`, `logs`, and `unitsConsumed`), `builder.view()` runs a view function, and `builder.pubkeys()` returns the resolved `Map<String, PublicKey?>` without executing.
+
+### Build an IDL programmatically for Pinocchio or native programs
+
+When there is no JSON IDL, define the interface with the `ProgramInterface` builder. The resulting `Idl` works with the same `program.methods` and `program.account` API.
+
+```dart
+import 'package:coral_xyz/coral_xyz.dart';
+
+Program buildNativeProgram(AnchorProvider provider) {
+  final idl = ProgramInterface.define(
+    name: 'my_program',
+    address: 'A9yYAEQ1sCfZbR5o',
+    version: '0.1.0',
+  )
+    .instruction('initialize', discriminator: [0])
+      .account('counter', writable: true, signer: false)
+      .account('payer', writable: true, signer: true)
+      .account('systemProgram')
+      .arg('initialValue', IdlType(kind: 'u64'))
+      .done()
+    .instruction('increment', discriminator: [1])
+      .account('counter', writable: true)
+      .arg('amount', IdlType(kind: 'u64'))
+      .done()
+    .account('Counter', discriminator: [0xFF, 0x01])
+      .field('count', IdlType(kind: 'u64'))
+      .field('authority', IdlType(kind: 'pubkey'))
+      .done()
+    .error(6000, 'Overflow', msg: 'Counter overflowed')
+    .build();
+
+  return Program(idl, provider: provider);
+}
+```
+
+### Decode an account with nested structs
+
+The coder auto-deserializes nested types from the IDL. Cast each field to the type the IDL maps it to.
+
+```dart
+import 'package:coral_xyz/coral_xyz.dart';
+
+class PollOption {
+  PollOption({required this.label, required this.id, required this.votes});
+  final String label;
+  final int id;
+  final int votes;
+}
+
+Future<List<PollOption>> fetchPollOptions(
+  Program program,
+  PublicKey pollAddress,
+) async {
+  final data = await program.account['Poll']!.fetch(pollAddress);
+
+  final rawOptions = data['options'] as List;
+  return rawOptions.map((opt) {
+    final m = opt as Map<String, dynamic>;
+    return PollOption(
+      label: m['label'] as String,
+      id: (m['id'] as BigInt).toInt(),    // u64 decodes to BigInt
+      votes: (m['votes'] as BigInt).toInt(),
+    );
+  }).toList();
+}
+```
+
+### Subscribe to events
+
+```dart
+import 'package:coral_xyz/coral_xyz.dart';
+
+int subscribeToCounter(Program program) {
+  final listenerId = program.addEventListener<Map<String, dynamic>>(
+    'CounterIncremented',
+    (event, slot, signature) {
+      print('Event at slot $slot: new count ${event['newCount']}');
+    },
+  );
+  return listenerId; // pass to program.removeEventListener(listenerId) later
+}
+```
+
+## Guidelines
+
+- DO cast to `dynamic` for IDL method names in Flutter: `(program.methods as dynamic).initialize()`. Dart's static type system cannot resolve IDL-defined names at compile time, so the `noSuchMethod` override on `MethodsNamespace` routes the call. This mirrors `program.methods.initialize()` in TypeScript Anchor.
+- DO use `AnchorProvider(connection, wallet)` for any write. `AnchorProvider.readOnly()` has no wallet, so calling `.rpc()` on it fails with a wallet-null error. Use read-only only for `program.account['myAccount'].fetch()`.
+- DO decode u64, i64, u128, and i128 fields as `BigInt`. Cast with `(data['count'] as BigInt).toInt()` only when the value is below 2^53.
+- DO derive PDAs with the deployed program ID. A program's hardcoded `ID_BYTES` in Rust source often differs from the deployed keypair, and a mismatch produces a different PDA than the program expects.
+- DO match IDL account map keys exactly. The IDL may use camelCase where you wrote snake_case. Check `program.idl.findInstruction('methodName')?.accounts`.
+- DON'T call `Program(idl)` when the IDL JSON has no `address` field. It throws "address required". Inject `idlMap['address'] = id` before `Idl.fromJson()`, or use `Program.withProgramId()`.
+- DON'T treat account results as typed classes. They are `Map<String, dynamic>` keyed by IDL field names. PublicKey fields come back as `Ed25519HDPublicKey`, nested structs as nested maps.
+- DON'T pass a PDA-derived account that the IDL has no seed definitions for and expect auto-resolution. `AccountsResolver` only auto-derives when the IDL has `pda.seeds`; otherwise pass the PDA explicitly in `.accounts({'config': configPda})`.
+
+## Common Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `Program(idl)` throws "address required" | IDL JSON has no `address` field | Inject `idlMap['address'] = id` before `Idl.fromJson()`, or use `Program.withProgramId(idl, publicKey)` |
+| `.rpc()` fails with "wallet is null" | Program built on `AnchorProvider.readOnly()` | Rebuild with `AnchorProvider(connection, wallet)` for writes |
+| Dynamic method cast required | `MethodsNamespace` uses `noSuchMethod` for dispatch | Use `(program.methods as dynamic).methodName(args)` |
+| `BigInt` where `int` expected | IDL u64, i64, u128, i128 fields decode to `BigInt` | Cast with `(data['count'] as BigInt).toInt()`, safe below 2^53 |
+| PDA mismatch between Dart and Rust | Hardcoded `ID_BYTES` in Rust differs from the deployed keypair | Derive with the DEPLOYED program ID, not the hardcoded test ID |
+| Account fetch returns `null` | Account not initialized on-chain yet | Call the initialize instruction first, or null-check the fetch result |
+| Accounts map keys rejected | IDL uses camelCase but you passed snake_case (or vice versa) | Match IDL names from `program.idl.findInstruction(name)?.accounts` |
+| `AccountsResolver` cannot auto-derive a PDA | IDL lacks `pda.seeds` for that account | Pass the PDA explicitly in `.accounts({'pool': poolPda})` |
+
+## References
+
+- coral_xyz on pub.dev: https://pub.dev/packages/coral_xyz (pre-1.0, v1.0.0-beta.x, so the API may shift between betas; pin `coral_xyz: ^1.0.0-beta.9`)
+- solana Dart SDK: https://pub.dev/packages/solana
+- Anchor framework and IDL format: https://www.anchor-lang.com
+- Solana PDA documentation: https://solana.com/docs/core/pda
+- Related skills in this set: solana-mobile-wallet-adapter-flutter, solana-dart-sdk, building-solana-transactions-flutter

--- a/skills/flutter-solana-domain-resolution/SKILL.md
+++ b/skills/flutter-solana-domain-resolution/SKILL.md
@@ -1,0 +1,330 @@
+---
+name: flutter-solana-domain-resolution
+description: Resolve Solana domains in Flutter and Dart with the tld_parser SDK for the AllDomains Alternative Name Service (ANS), covering every custom TLD like .skr, .bonk, .backpack, and .solana. Use for forward lookup (domain to wallet), reverse lookup (wallet to main domain), reading records and avatars, listing user domains including NFT-wrapped ones, and batch resolution. ANS is a different protocol from Bonfida SNS (.sol), so use this when you need any TLD other than .sol.
+license: MIT
+metadata:
+  author: Dominion Nwakanma (web3flutter.dev)
+  version: "1.0.0"
+tags:
+  - solana
+  - alldomains
+  - ans
+  - domain-resolution
+  - tld-parser
+  - flutter
+  - dart
+  - sns
+  - name-service
+---
+
+# Solana Domain Resolution for Flutter (AllDomains ANS)
+
+## Overview
+
+`tld_parser` is the Dart SDK for the AllDomains Alternative Name Service (ANS) on Solana. It resolves domains with any TLD: `.skr`, `.bonk`, `.backpack`, `.solana`, `.blink`, `.monke`, and the rest. This is not the Bonfida SNS SDK. SNS only handles `.sol`. ANS handles everything else.
+
+The two protocols are incompatible at the cryptographic level. SNS hashes names with the prefix `"SPL Name Service"` and uses program `namesLPneVptA9Z5rqUDD9tMTWEJwofgaYwp8cawRkX`. ANS hashes with the prefix `"ALT Name Service"` and uses program `ALTNSZ46uaAUU7XUV6awvdorLGqAsPwa9shm7h4uP2FK`. Every PDA derivation is different. You cannot resolve a `.sol` name through `tld_parser` or a `.bonk` name through `sns_sdk`. Most production apps run both side by side.
+
+Three on-chain programs power AllDomains. ANS (`ALTNSZ46uaAUU7XUV6awvdorLGqAsPwa9shm7h4uP2FK`) is the name registry that stores domain to owner mappings. TLD House (`TLDHkysf5pCnKsVA4gXpNvmy7psXLPEu4LAdDJthT9S`) governs which TLDs exist. Name House (`NH3uX6FtVE2fNREAioP7hm5RaozotZxeL6khU1EHx51`) handles domains wrapped as NFTs.
+
+AllDomains data lives on mainnet only. There is no devnet deployment. If you point `TldParser` at devnet, every lookup returns `null` and it looks like a deserialization bug.
+
+## Instructions
+
+1. Add `tld_parser: ^0.1.0` and `solana: ^0.31.0` to pubspec.yaml.
+2. Construct `TldParser(rpcClient)` with a `solana.RpcClient`. Do NOT pass `SolanaClient` or `HttpRpcClient`. The constructor wants the raw `RpcClient` from `package:solana/solana.dart`.
+3. Point the RpcClient at a mainnet URL even if the rest of your app uses devnet. A Helius or mainnet-beta endpoint is required.
+4. Normalize every domain string with `.toLowerCase()` before passing it. The on-chain hash is computed from lowercase bytes, so `Miester.abc` and `miester.abc` derive different PDAs. The SDK does not auto-lowercase.
+5. For forward lookup (domain to address), call `getOwnerFromDomainTld('name.tld')` with the full domain including the TLD. It returns `Ed25519HDPublicKey?` and gives `null` for missing domains.
+6. For reverse lookup (address to main domain), call `tryGetMainDomain(pubkey)`, not `getMainDomain`. The throwing version spams logs because most wallets have no main domain set.
+7. Build the full domain string as `'${main.domain}${main.tld}'`. The `tld` field already includes the leading dot.
+8. Reuse one `TldParser` instance through a singleton. Add an in-memory cache and dedup concurrent lookups for the same key.
+9. For lists (leaderboards, transaction history), pre-resolve all addresses with `Future.wait` before building widgets. Do not rely on `FutureBuilder` per row.
+
+## Examples
+
+### Production singleton resolver with cache and dedup
+
+Forward and reverse lookup behind one reusable instance. The cache stops duplicate RPC calls and the pending map dedups concurrent lookups for the same address. This is the pattern used in Chumbucket's address name resolver.
+
+```dart
+import 'package:tld_parser/tld_parser.dart';
+import 'package:solana/solana.dart' as solana;
+
+class DomainResolver {
+  static TldParser? _tldParser;
+  static final Map<String, String> _cache = {};
+  static final Map<String, DateTime> _timestamps = {};
+  static final Map<String, Future<String>> _pending = {};
+  static const Duration _cacheExpiry = Duration(hours: 1);
+
+  static const List<String> _allDomainsTlds = [
+    '.skr', '.bonk', '.backpack', '.blink', '.monke', '.ninja', '.solana',
+  ];
+
+  static TldParser _getParser() {
+    return _tldParser ??= TldParser(
+      solana.RpcClient('https://mainnet.helius-rpc.com/?api-key=YOUR_KEY'),
+    );
+  }
+
+  /// Forward: domain to address.
+  static Future<String?> resolveDomainToAddress(String domain) async {
+    final normalized = domain.trim().toLowerCase();
+    if (normalized.isEmpty) return null;
+
+    final cacheKey = 'addr:$normalized';
+    if (_cache.containsKey(cacheKey)) return _cache[cacheKey];
+
+    if (!_allDomainsTlds.any((ext) => normalized.endsWith(ext))) return null;
+
+    try {
+      final owner = await _getParser().getOwnerFromDomainTld(normalized);
+      if (owner != null) {
+        final address = owner.toBase58();
+        _cache[cacheKey] = address;
+        return address;
+      }
+    } catch (e) {
+      // Log but do not throw. Domain resolution is never on the critical path.
+    }
+    return null;
+  }
+
+  /// Reverse: address to display name, with caching and dedup.
+  static Future<String> resolveAddressToName(String address) async {
+    final cacheKey = 'name:$address';
+
+    if (_cache.containsKey(cacheKey)) {
+      final ts = _timestamps[cacheKey];
+      if (ts != null && DateTime.now().difference(ts) < _cacheExpiry) {
+        return _cache[cacheKey]!;
+      }
+      _cache.remove(cacheKey);
+      _timestamps.remove(cacheKey);
+    }
+
+    if (_pending.containsKey(cacheKey)) return _pending[cacheKey]!;
+
+    final future = _doReverseLookup(address, cacheKey);
+    _pending[cacheKey] = future;
+    try {
+      return await future;
+    } finally {
+      _pending.remove(cacheKey);
+    }
+  }
+
+  static Future<String> _doReverseLookup(String address, String cacheKey) async {
+    try {
+      final pubkey = solana.Ed25519HDPublicKey.fromBase58(address);
+      final main = await _getParser().tryGetMainDomain(pubkey);
+      if (main != null && main.domain.isNotEmpty) {
+        final name = '${main.domain}${main.tld}';
+        _cache[cacheKey] = name;
+        _timestamps[cacheKey] = DateTime.now();
+        return name;
+      }
+    } catch (_) {}
+
+    final short =
+        '${address.substring(0, 6)}..${address.substring(address.length - 4)}';
+    _cache[cacheKey] = short;
+    _timestamps[cacheKey] = DateTime.now();
+    return short;
+  }
+}
+```
+
+### Forward and reverse lookup
+
+```dart
+import 'package:tld_parser/tld_parser.dart';
+import 'package:solana/solana.dart';
+
+Future<void> lookups(TldParser parser) async {
+  // Forward: pass the FULL domain including the TLD, lowercased.
+  final owner = await parser.getOwnerFromDomainTld('miester.abc');
+  if (owner != null) {
+    print('Owner: ${owner.toBase58()}');
+  }
+
+  // Subdomains use the same call: sub.domain.tld.
+  final vaultOwner = await parser.getOwnerFromDomainTld('vault.miester.abc');
+  if (vaultOwner != null) {
+    print('Vault owner: ${vaultOwner.toBase58()}');
+  }
+
+  // Reverse: tryGetMainDomain returns null instead of throwing.
+  final pubkey = Ed25519HDPublicKey.fromBase58(
+    'Ggg9b4AZaQehNoQGfckVhKMNQiGF7XbGYWkWAsiJMTV5',
+  );
+  final main = await parser.tryGetMainDomain(pubkey);
+  if (main != null) {
+    // main.tld already includes the leading dot, so do not add one.
+    print('Main domain: ${main.domain}${main.tld}'); // "miester.abc"
+  }
+}
+```
+
+### Reading records and resolving avatars
+
+```dart
+import 'package:tld_parser/tld_parser.dart';
+
+Future<void> readProfile(TldParser parser) async {
+  // Single record. Returns String? and null if unset.
+  final twitter = await parser.getRecord('miester.abc', Record.twitter);
+  if (twitter != null) print('Twitter: $twitter');
+
+  // Several specific records in one call.
+  final result = await parser.getRecords('miester.abc', [
+    Record.twitter,
+    Record.discord,
+    Record.avatar,
+    Record.displayName,
+  ]);
+  final discord = result.records[Record.discord];
+  if (discord != null) print('Discord: $discord');
+
+  // Avatar resolution with protocol detection. IPFS hashes become gateway
+  // URLs, Arweave IDs become arweave.net URLs, NFT references resolve to the
+  // metadata image, data URIs and direct URLs pass through unchanged.
+  final avatarUrl = await parser.getAvatar('miester.abc');
+  if (avatarUrl != null) print('Avatar: $avatarUrl');
+}
+```
+
+### Listing a wallet's domains including NFT-wrapped
+
+```dart
+import 'package:tld_parser/tld_parser.dart';
+import 'package:solana/solana.dart';
+
+Future<void> listDomains(TldParser parser) async {
+  final pubkey = Ed25519HDPublicKey.fromBase58(
+    'Ggg9b4AZaQehNoQGfckVhKMNQiGF7XbGYWkWAsiJMTV5',
+  );
+
+  // Fast: just the name account public keys, one RPC call, no NFTs.
+  final domainKeys = await parser.getAllUserDomains(pubkey);
+  print('Owns ${domainKeys.length} name accounts');
+
+  // Parsed with domain names. Costs more RPC calls.
+  final parsed = await parser.getParsedAllUserDomains(pubkey);
+  for (final d in parsed) {
+    print('${d.domainName} -> ${d.nameAccount.toBase58()}');
+  }
+
+  // Includes both directly-owned and NFT-wrapped domains. Extra RPC per domain
+  // to check NFT ownership, so use only when you actually need the wrapped set.
+  final unwrapped = await parser.getParsedAllUserDomainsUnwrapped(pubkey);
+  print('Owns ${unwrapped.length} domains including NFT-wrapped');
+}
+```
+
+### Batch reverse lookup
+
+```dart
+import 'package:tld_parser/tld_parser.dart';
+import 'package:solana/solana.dart';
+
+Future<void> batch(TldParser parser) async {
+  final addresses = [
+    'Ggg9b4AZaQehNoQGfckVhKMNQiGF7XbGYWkWAsiJMTV5',
+    '7M3RL9Tnsf5pCnKsVA4gXpNvmy7psXLPEu4LAdDJthT9',
+  ];
+  final pubkeys = addresses.map(Ed25519HDPublicKey.fromBase58).toList();
+
+  // One call for many addresses. Returns List<String?>, null where no main
+  // domain is set.
+  final mainDomains = await parser.getMainDomains(pubkeys);
+  for (var i = 0; i < addresses.length; i++) {
+    print('${addresses[i]} -> ${mainDomains[i] ?? "(no main domain)"}');
+  }
+}
+```
+
+### Pre-resolving a list to avoid FutureBuilder flash
+
+`FutureBuilder` reruns on every parent rebuild. Even with the cache, each row flashes from address to name. For leaderboards and transaction histories, resolve the whole batch up front, then feed plain strings into widgets.
+
+```dart
+import 'package:flutter/material.dart';
+
+class ResolvedNameList extends StatefulWidget {
+  const ResolvedNameList({super.key, required this.addresses});
+  final List<String> addresses;
+
+  @override
+  State<ResolvedNameList> createState() => _ResolvedNameListState();
+}
+
+class _ResolvedNameListState extends State<ResolvedNameList> {
+  List<String> _names = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _resolveAll();
+  }
+
+  Future<void> _resolveAll() async {
+    final names = await Future.wait(
+      widget.addresses.map(DomainResolver.resolveAddressToName),
+    );
+    if (mounted) setState(() => _names = names);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_names.isEmpty) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    return ListView.builder(
+      itemCount: _names.length,
+      itemBuilder: (context, i) => ListTile(
+        title: Text(_names[i], maxLines: 1, overflow: TextOverflow.ellipsis),
+      ),
+    );
+  }
+}
+```
+
+## Guidelines
+
+- DO point `TldParser` at a mainnet RPC. AllDomains has no devnet deployment, so devnet lookups always return `null`.
+- DO pass `solana.RpcClient` to the constructor. Not `SolanaClient`, not `HttpRpcClient` from `sns_sdk`.
+- DO lowercase every domain string before any lookup. The hash is over lowercase bytes.
+- DO pass the full `domain.tld` including the TLD. `getOwnerFromDomainTld('miester')` cannot pick a namespace and throws.
+- DO use `tryGetMainDomain` in production. `getMainDomain` throws `MainDomainNotFoundException` for the common case of no main domain.
+- DO build the full domain as `'${main.domain}${main.tld}'`. The `tld` already has the dot.
+- DO reuse one `TldParser` through a singleton and cache results. A new parser per call wastes connections.
+- DON'T treat the return of `getOwnerFromDomainTld` as a `String`. SNS returns a base58 `String`, ANS returns `Ed25519HDPublicKey?`. Call `.toBase58()`.
+- DON'T reuse SNS hash logic. ANS uses `"ALT Name Service"`, not `"SPL Name Service"`, so the PDAs differ.
+- DON'T call `getAllRecords` casually. It fetches all 27 record types. Use `getRecords` with a short list.
+- DON'T hardcode TLD parent accounts. Discover them with `getAllTld()` and cache, since TLD-scoped queries like `getAllUserDomainsFromTld` need the parent account.
+
+## Common Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| Type error passing client to `TldParser()` | Passed `SolanaClient` or `sns_sdk`'s `HttpRpcClient` | Pass `solana.RpcClient(url)` directly |
+| Every lookup returns null | RPC pointed at devnet | Use a mainnet RPC. AllDomains exists on mainnet only |
+| Resolves on web but not for typed input | Input not lowercased | Call `.toLowerCase()` before every lookup |
+| `getOwnerFromDomainTld('miester')` throws | TLD missing from the domain string | Pass the full `domain.tld`, including the extension |
+| `MainDomainNotFoundException` floods logs | Used `getMainDomain` for wallets with no main domain | Use `tryGetMainDomain`, which returns `null` |
+| Full domain renders as `miester..abc` | Added a dot before `main.tld` | `main.tld` already includes the dot: `'${main.domain}${main.tld}'` |
+| `.sol` names never resolve | Routed `.sol` through `tld_parser` | Use `sns_sdk` for `.sol`. ANS and SNS are different protocols |
+| `NullPointerException` on resolve result | Assumed a domain always resolves | Null-check `getOwnerFromDomainTld`, it returns `null` for missing domains |
+| List rows flash from address to name | One `FutureBuilder` per row reruns on rebuild | Pre-resolve the batch with `Future.wait`, pass strings to widgets |
+
+## References
+
+- tld_parser is pinned low at `^0.1.0`. Verify method names (`getOwnerFromDomainTld`, `tryGetMainDomain`, `getMainDomains`, `getParsedAllUserDomainsUnwrapped`, `getRecords`, `getAvatar`, `getAllTld`) against the current pub.dev page before shipping, since the API can drift between patch releases.
+- tld_parser on pub.dev: https://pub.dev/packages/tld_parser
+- tld_parser on GitHub: https://github.com/onsol-labs/tld-parser-dart
+- AllDomains: https://alldomains.id
+- AllDomains docs: https://docs.alldomains.id
+- solana Dart SDK: https://pub.dev/packages/solana
+- Related skills in this set: solana-dart-sdk, solana-mobile-wallet-adapter-flutter, flutter-solana-wallet-security

--- a/skills/flutter-solana-metaplex-nft/SKILL.md
+++ b/skills/flutter-solana-metaplex-nft/SKILL.md
@@ -1,0 +1,333 @@
+---
+name: flutter-solana-metaplex-nft
+description: Mint and read Solana NFTs from Flutter and Dart using the Metaplex Token Metadata program built into package:solana via package:solana/metaplex.dart. Use to create a 0-decimal NFT mint plus master edition, build createMetadataAccountV3 and createMasterEditionV3 instructions, parse on-chain Metadata and MasterEdition accounts, read off-chain JSON metadata, and run a backend-mediated MWA-signed mint on mobile.
+license: MIT
+metadata:
+  author: Dominion Nwakanma (web3flutter.dev)
+  version: "1.0.0"
+tags:
+  - solana
+  - metaplex
+  - nft
+  - token-metadata
+  - master-edition
+  - flutter
+  - dart
+  - mobile-wallet-adapter
+---
+
+# Metaplex NFTs for Flutter and Dart
+
+## Overview
+
+Metaplex Token Metadata support is built into the `solana` package. There is no separate Metaplex SDK to add. You import the extra types and instruction builders from `package:solana/metaplex.dart`, alongside the usual `package:solana/solana.dart`.
+
+The package gives you four things:
+
+1. Instruction builders. `createMetadataAccountV3()` and `createMasterEditionV3()` return `AnchorInstruction` objects you drop into a `Message`.
+2. Account parsers. `Metadata.fromBinary()` and `MasterEdition.fromBorsh()` read the raw on-chain accounts.
+3. RPC extensions. `getMetadata()` and `getMasterEdition()` derive the PDA, fetch, and parse for you.
+4. Off-chain models. `OffChainMetadata`, `Attribute`, `Properties`, `Collection`, and `File` model the JSON standard pointed to by the `uri` field.
+
+The mint, ATA, and account-fetch helpers (`initializeMint`, `createAssociatedTokenAccount`, `mintTo`, `getMetadata`, `getMasterEdition`) are extension methods on `SolanaClient` and `RpcClient` from `package:solana`. They only resolve when that import is present.
+
+The Metaplex program ID is `metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s`. Pin `solana: ^0.31.2` or newer.
+
+## Instructions
+
+1. Add `solana: ^0.31.2` to pubspec.yaml.
+2. Import both `package:solana/solana.dart` and `package:solana/metaplex.dart`. The first import brings in the `SolanaClient` and `RpcClient` extension methods used below; the second brings in the Metaplex types.
+3. Create the mint with `initializeMint(decimals: 0)`. An NFT is a mint with 0 decimals and a supply of exactly 1.
+4. Create the associated token account with `createAssociatedTokenAccount`, then `mintTo` with `amount: 1`.
+5. Build the metadata instruction with `createMetadataAccountV3` and send it before the master edition. The master edition instruction needs the metadata PDA to already exist.
+6. Build the master edition instruction with `createMasterEditionV3`. Pass `maxSupply: BigInt.zero` for no prints, or `null` for unlimited prints.
+7. To read an NFT, call `rpcClient.getMetadata(mint:)`. It returns `Metadata?`, null when the account does not exist. Call `getExternalJson()` on the result to fetch and parse the off-chain JSON.
+8. On mobile, do not ship the update authority key in the app. Build the instructions on a backend, return the encoded transaction, sign it with Mobile Wallet Adapter, and submit from the backend.
+
+## Examples
+
+### Full 4-step mint (0-decimal mint plus master edition)
+
+Create the mint, mint one token, write metadata, then promote it to a master edition. Each step is sent as its own transaction.
+
+```dart
+import 'package:solana/solana.dart';
+import 'package:solana/metaplex.dart';
+
+Future<void> mintNft(SolanaClient client, Ed25519HDKeyPair owner) async {
+  // 1. Create a mint with 0 decimals. An NFT is 0 decimals, supply 1.
+  // initializeMint is a SolanaClient extension method from package:solana.
+  final mint = await client.initializeMint(
+    mintAuthority: owner,
+    decimals: 0,
+  );
+
+  // 2. Create the ATA and mint exactly 1 token.
+  // createAssociatedTokenAccount and mintTo are SolanaClient extensions.
+  final ata = await client.createAssociatedTokenAccount(
+    mint: mint.address,
+    funder: owner,
+  );
+  await client.mintTo(
+    mint: mint.address,
+    destination: Ed25519HDPublicKey.fromBase58(ata.pubkey),
+    amount: 1,
+    authority: owner,
+  );
+
+  // 3. Create the metadata account.
+  final metadataIx = await createMetadataAccountV3(
+    mint: mint.address,
+    mintAuthority: owner.publicKey,
+    payer: owner.publicKey,
+    updateAuthority: owner.publicKey,
+    data: CreateMetadataAccountV3Data(
+      name: 'My NFT',
+      symbol: 'MNFT',
+      uri: 'https://arweave.net/your-metadata.json',
+      sellerFeeBasisPoints: 500, // 5% royalty
+      isMutable: true,
+      // NOTE: "colectionDetails" is a known upstream typo in package:solana
+      // (missing an l). Keep the misspelling; that is the real field name.
+      colectionDetails: false,
+    ),
+  );
+  await client.sendAndConfirmTransaction(
+    message: Message.only(metadataIx),
+    signers: [owner],
+    onSigned: ignoreOnSigned,
+  );
+
+  // 4. Create the master edition. This makes it a true NFT.
+  final editionIx = await createMasterEditionV3(
+    mint: mint.address,
+    updateAuthority: owner.publicKey,
+    mintAuthority: owner.publicKey,
+    payer: owner.publicKey,
+    data: CreateMasterEditionV3Data(
+      maxSupply: BigInt.zero, // BigInt.zero = no prints allowed
+    ),
+  );
+  await client.sendAndConfirmTransaction(
+    message: Message.only(editionIx),
+    signers: [owner],
+    onSigned: ignoreOnSigned,
+  );
+}
+```
+
+### Read on-chain Metadata and MasterEdition
+
+`getMetadata` and `getMasterEdition` are `RpcClient` extension methods. They derive the PDA, fetch the account, and parse it. Both return null when the account is missing.
+
+```dart
+import 'package:solana/solana.dart';
+import 'package:solana/metaplex.dart';
+
+Future<void> readNft(RpcClient rpc, Ed25519HDPublicKey mintPubKey) async {
+  final metadata = await rpc.getMetadata(
+    mint: mintPubKey,
+    commitment: Commitment.finalized,
+  );
+  if (metadata != null) {
+    print(metadata.name);             // 'My NFT'
+    print(metadata.symbol);           // 'MNFT'
+    print(metadata.uri);              // 'https://arweave.net/your-metadata.json'
+    print(metadata.updateAuthority);  // base58 string
+    print(metadata.mint);             // base58 string
+  }
+
+  final edition = await rpc.getMasterEdition(mint: mintPubKey);
+  if (edition != null) {
+    print(edition.key);        // 6 = MasterEditionV2
+    print(edition.supply);     // BigInt, prints minted so far
+    print(edition.maxSupply);  // BigInt?, null = unlimited, 0 = no prints
+  }
+}
+```
+
+### Parse off-chain JSON metadata
+
+The on-chain `uri` points to JSON. `getExternalJson()` fetches and parses it into an `OffChainMetadata`. `Properties` is a freezed union discriminated by the JSON `category` field, so resolve it with `map`.
+
+```dart
+import 'package:solana/solana.dart';
+import 'package:solana/metaplex.dart';
+
+Future<void> readOffChain(Metadata metadata) async {
+  final offChain = await metadata.getExternalJson();
+
+  print(offChain.name);         // 'My NFT'
+  print(offChain.description);  // 'A cool NFT'
+  print(offChain.symbol);       // 'MNFT'
+  print(offChain.image);        // 'https://arweave.net/image.png'
+
+  // Attributes are trait_type and value pairs. value is dynamic.
+  for (final attr in offChain.attributes) {
+    print(attr.traitType);  // 'Background'
+    print(attr.value);      // 'Blue', can be String, int, etc.
+  }
+
+  // Properties is a freezed union keyed on media category.
+  final mediaUri = offChain.properties.map(
+    unknown: (_) => null,
+    image: (p) => p.files.first.uri,
+    video: (p) => p.files.first.uri,
+    audio: (p) => p.files.first.uri,
+    vr: (p) => p.files.first.uri,
+    html: (p) => p.files.first.uri,
+  );
+  print(mediaUri);
+
+  print(offChain.collection?.name);    // 'My Collection'
+  print(offChain.collection?.family);  // 'My Family'
+}
+```
+
+### Backend-mediated mint signed with MWA (mobile)
+
+On mobile you must not embed the update authority key. Build the Metaplex instructions on a backend, return the encoded transaction, sign it with Mobile Wallet Adapter, and let the backend submit. The placeholder calls (`uploadService`, `backendApi`, `mwaClient`, `wallet`, `token`) are your own app services.
+
+```dart
+import 'dart:convert';
+
+Future<String> mintViaBackend({
+  required UploadService uploadService,
+  required BackendApi backendApi,
+  required MobileWalletAdapterClient mwaClient,
+  required Wallet wallet,
+  required String token,
+  required String name,
+  required String imagePath,
+  required List<MapEntry<String, String>> attributes,
+}) async {
+  // 1. Upload media and JSON metadata to Arweave or IPFS.
+  final metadataUri = await uploadService.upload(name, imagePath, attributes);
+
+  // 2. Backend builds the Metaplex instructions server-side.
+  final preparedTx = await backendApi.prepareNft(
+    walletAddress: wallet.address,
+    name: name,
+    symbol: 'MNFT',
+    metadataUri: metadataUri,
+    sellerFeeBasisPoints: 500,
+    creators: [CreatorDto(address: wallet.address, share: 100)],
+  );
+
+  // 3. Sign the prepared transaction with MWA.
+  final signed = await mwaClient.signTransactions(
+    transactions: [base64Decode(preparedTx.encodedTx)],
+  );
+
+  // 4. Backend submits the signed transaction and returns the signature.
+  return backendApi.finalizeNft(
+    preparedTx.id,
+    base64Encode(signed.signedPayloads.first),
+  );
+}
+```
+
+### Build a gallery from a list of mints
+
+Fetch each NFT's on-chain metadata, then resolve the off-chain JSON. Skip mints with missing or unreachable metadata.
+
+```dart
+import 'package:solana/solana.dart';
+import 'package:solana/metaplex.dart';
+
+Future<List<OffChainMetadata>> fetchNfts(
+  RpcClient rpc,
+  List<Ed25519HDPublicKey> mints,
+) async {
+  final results = <OffChainMetadata>[];
+  for (final mint in mints) {
+    final metadata = await rpc.getMetadata(mint: mint);
+    if (metadata == null) continue;
+    try {
+      results.add(await metadata.getExternalJson());
+    } catch (_) {
+      // The uri may be invalid or unreachable. Skip it.
+    }
+  }
+  return results;
+}
+```
+
+## Reference: instruction data fields
+
+`CreateMetadataAccountV3Data` fields passed to `createMetadataAccountV3`:
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `name` | `String` | Fixed 32 bytes (BFixedString) |
+| `symbol` | `String` | Fixed 10 bytes |
+| `uri` | `String` | Fixed 200 bytes, off-chain JSON URL |
+| `sellerFeeBasisPoints` | `int` | Royalty in bps (500 = 5%) |
+| `creators` | `List<MetadataCreator>?` | Optional creator list, shares must sum to 100 |
+| `collection` | `MetadataCollection?` | Collection verification |
+| `uses` | `MetadataUses?` | Usage tracking |
+| `isMutable` | `bool` | Whether metadata can be updated later |
+| `colectionDetails` | `bool` | Collection details flag. Misspelled in the real API (known upstream typo, missing an l). Use it as written |
+
+`CreateMasterEditionV3Data` has one field, `maxSupply` of type `BigInt?`. `null` means unlimited prints, `BigInt.zero` means no prints.
+
+Supporting types from `package:solana/metaplex.dart`:
+
+```dart
+import 'package:solana/solana.dart';
+import 'package:solana/metaplex.dart';
+
+void supportingTypes(Ed25519HDPublicKey creatorPubKey,
+    Ed25519HDPublicKey collectionMintPubKey) {
+  MetadataCreator(
+    address: creatorPubKey,
+    verified: false, // only true after on-chain verification
+    share: 100,      // 0 to 100, must sum to 100 across all creators
+  );
+
+  MetadataCollection(
+    verified: false, // only true after the collection authority verifies
+    key: collectionMintPubKey,
+  );
+
+  MetadataUses(
+    useMethod: 0,    // 0 = Burn, 1 = Multiple, 2 = Single
+    remaining: BigInt.from(1),
+    total: BigInt.from(1),
+  );
+}
+```
+
+## Guidelines
+
+- DO use `decimals: 0` for the mint and mint exactly 1 token. That is what makes the asset an NFT.
+- DO send the metadata transaction before the master edition transaction. The master edition needs the metadata PDA to exist.
+- DO use `rpcClient.getMetadata(mint:)` and `getMasterEdition(mint:)` for reads. They derive the PDA for you.
+- DO null-check the result of `getMetadata` and `getMasterEdition`. Both return null for missing accounts.
+- DO keep the `colectionDetails` spelling exactly as the package defines it. It is misspelled upstream and will not resolve if you "correct" it.
+- DO import `package:solana/metaplex.dart` for the Metaplex types and `package:solana/solana.dart` for the client extension methods. Both are required.
+- DON'T set `maxSupply: null` when you want a 1-of-1 with no prints. `null` means unlimited. Use `BigInt.zero`.
+- DON'T set `verified: true` on a creator or collection that has not been verified on-chain. Only the signing creator can be verified at creation time.
+- DON'T mint more than 1 token before creating the master edition. The master edition instruction expects a supply of 1.
+- DON'T embed the update authority key in a mobile app. Build instructions on a backend and sign with MWA.
+- DON'T call the internal PDA helper `findMetaplexMetadataProgramAddress` directly. Go through the RPC extensions.
+
+## Common Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `colectionDetails` is not defined | Spelling "corrected" to `collectionDetails` | Use `colectionDetails`, the real field is misspelled upstream |
+| `initializeMint` / `getMetadata` is not defined | Missing `package:solana/solana.dart` import | These are extension methods from `package:solana`, import it |
+| Master edition instruction fails | Metadata account does not exist yet | Send `createMetadataAccountV3` before `createMasterEditionV3` |
+| NFT shows fractional balance or supply above 1 | Mint created with non-zero decimals or over-minted | Use `decimals: 0` and `mintTo(amount: 1)` |
+| Unlimited prints created by accident | `maxSupply: null` used for a 1-of-1 | Pass `maxSupply: BigInt.zero` for no prints |
+| Transaction rejected, creator shares invalid | `MetadataCreator.share` values do not sum to 100 | Make all creator shares sum to exactly 100 |
+| Creator or collection stays unverified | `verified: true` set without on-chain verification | Set `verified: false` at creation, verify on-chain later |
+| `getExternalJson()` throws | The `uri` is invalid or the host is unreachable | Wrap in try/catch and skip, as in the gallery example |
+
+## References
+
+- solana Dart SDK on pub.dev: https://pub.dev/packages/solana
+- Metaplex Token Metadata program docs: https://developers.metaplex.com/token-metadata
+- Token Metadata standard (off-chain JSON): https://developers.metaplex.com/token-metadata/token-standard
+- Related skills in this set: solana-dart-sdk, building-solana-transactions-flutter, solana-mobile-wallet-adapter-flutter

--- a/skills/flutter-solana-wallet-security/SKILL.md
+++ b/skills/flutter-solana-wallet-security/SKILL.md
@@ -1,0 +1,363 @@
+---
+name: flutter-solana-wallet-security
+description: Harden Solana wallets and dApps built in Flutter and Dart. Encrypt seed phrases and private keys at rest, gate sensitive actions with biometrics, hash PINs with salted Argon2id, manage secrets with dotenv and dart-define, validate RPC endpoints, and simulate transactions before sending. Use for secure key storage, app lock, logout wipes, and pre-ship security review on mobile.
+license: MIT
+metadata:
+  author: Dominion Nwakanma (web3flutter.dev)
+  version: "1.0.0"
+tags:
+  - solana
+  - flutter
+  - dart
+  - security
+  - wallet
+  - secure-storage
+  - encryption
+  - biometrics
+  - mobile
+---
+
+# Flutter Solana Wallet Security
+
+## Overview
+
+Web3 mobile apps hold assets with real value. One plaintext private key leak means total, irreversible loss. Every layer has to be hardened: storage, encryption, secrets, biometric gating, network transport, and the signing flow.
+
+This skill covers the patterns that matter on mobile, with code that uses a cryptographically secure RNG, a fresh IV per encryption, and a salted Argon2id KDF for PINs. The patterns are drawn from production Solana Flutter apps.
+
+Packages used:
+
+| Package | Purpose |
+|---------|---------|
+| flutter_secure_storage | Keychain on iOS, EncryptedSharedPreferences on Android |
+| encrypt | AES-256-CBC |
+| crypto | SHA-256 for key derivation |
+| cryptography | Argon2id for PIN hashing |
+| local_auth | Face ID and fingerprint |
+| flutter_dotenv | Loading environment secrets |
+| bip39, ed25519_hd_key | Mnemonic and Solana keypair derivation |
+
+```yaml
+dependencies:
+  flutter_secure_storage: ^9.2.2
+  encrypt: ^5.0.3
+  crypto: ^3.0.3
+  cryptography: ^2.7.0
+  local_auth: ^2.3.0
+  flutter_dotenv: ^6.0.0
+  bip39: ^1.0.6
+  ed25519_hd_key: ^2.3.0
+```
+
+## Instructions
+
+1. Store every secret in flutter_secure_storage. Turn on `encryptedSharedPreferences: true` on Android and set a Keychain accessibility level on iOS.
+2. Add a second AES-256-CBC layer on top of secure storage for the most sensitive values (seed phrase, private key). Derive the key from a 32 byte value generated with `Random.secure()`, never from a timestamp.
+3. Use a fresh random IV for every encryption and store the IV with the ciphertext. Never reuse a fixed IV.
+4. Hash PINs with salted Argon2id, store the salt with the hash, and compare in constant time. Never store a bare SHA-256 of a PIN.
+5. Keep secrets out of source control. Load them with flutter_dotenv from a gitignored `.env`, or pass them with `--dart-define` for CI builds.
+6. Put a biometric gate in front of any action that reveals or uses key material (export mnemonic, sign a high value transaction). Decrypt the key only after the gate passes.
+7. Reject non HTTPS RPC endpoints and check unknown hosts against a user approved list.
+8. Simulate every transaction before sending so a bad transaction fails for free.
+9. Never log keys or mnemonics. On logout, wipe all secure storage.
+
+## Examples
+
+### Secure storage service with a real CSPRNG and a per-encryption IV
+
+```dart
+import 'dart:convert';
+import 'dart:math';
+import 'dart:typed_data';
+import 'package:crypto/crypto.dart';
+import 'package:encrypt/encrypt.dart' as encrypt;
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+class SecureStorageService {
+  SecureStorageService({required this.namespace})
+      : _storage = const FlutterSecureStorage(
+          aOptions: AndroidOptions(encryptedSharedPreferences: true),
+          iOptions: IOSOptions(
+            accessibility: KeychainAccessibility.first_unlock,
+          ),
+        );
+
+  final FlutterSecureStorage _storage;
+  final String namespace;
+
+  Future<void> saveValue(String key, String value) =>
+      _storage.write(key: '${namespace}_$key', value: value);
+
+  Future<String?> getValue(String key) =>
+      _storage.read(key: '${namespace}_$key');
+
+  Future<void> saveEncrypted(String key, String value) async {
+    final derivedKey = await _getDeviceSpecificKey();
+    await saveValue(key, _encryptAES(value, derivedKey));
+  }
+
+  Future<String?> getEncrypted(String key) async {
+    final stored = await getValue(key);
+    if (stored == null) return null;
+    final derivedKey = await _getDeviceSpecificKey();
+    try {
+      return _decryptAES(stored, derivedKey);
+    } catch (_) {
+      return null; // tampered, malformed, or wrong key
+    }
+  }
+
+  // 32 bytes from a cryptographically secure RNG, generated once per namespace.
+  Future<String> _getDeviceSpecificKey() async {
+    var deviceId = await getValue('device_id');
+    if (deviceId == null) {
+      final rnd = Random.secure();
+      final bytes = List<int>.generate(32, (_) => rnd.nextInt(256));
+      deviceId = bytes.map((b) => b.toRadixString(16).padLeft(2, '0')).join();
+      await saveValue('device_id', deviceId);
+    }
+    return sha256.convert(utf8.encode(deviceId + namespace)).toString();
+  }
+
+  // Returns "ivBase64:cipherBase64". A new IV is created for every call.
+  static String _encryptAES(String plainText, String key) {
+    final keyBytes = sha256.convert(utf8.encode(key)).bytes;
+    final iv = encrypt.IV.fromSecureRandom(16);
+    final encrypter = encrypt.Encrypter(
+      encrypt.AES(encrypt.Key(Uint8List.fromList(keyBytes)),
+          mode: encrypt.AESMode.cbc),
+    );
+    final ct = encrypter.encrypt(plainText, iv: iv);
+    return '${iv.base64}:${ct.base64}';
+  }
+
+  static String _decryptAES(String stored, String key) {
+    final parts = stored.split(':');
+    if (parts.length != 2) throw const FormatException('Malformed ciphertext');
+    final iv = encrypt.IV.fromBase64(parts[0]);
+    final keyBytes = sha256.convert(utf8.encode(key)).bytes;
+    final encrypter = encrypt.Encrypter(
+      encrypt.AES(encrypt.Key(Uint8List.fromList(keyBytes)),
+          mode: encrypt.AESMode.cbc),
+    );
+    return encrypter.decrypt64(parts[1], iv: iv);
+  }
+}
+```
+
+### Derive and store a Solana keypair, never in plaintext
+
+```dart
+import 'package:bip39/bip39.dart' as bip39;
+import 'package:ed25519_hd_key/ed25519_hd_key.dart';
+
+final mnemonic = bip39.generateMnemonic(); // 12 word BIP-39
+final seed = bip39.mnemonicToSeed(mnemonic);
+
+// Solana uses the BIP-44 path m/44'/501'/0'/0'
+final derived = await ED25519_HD_KEY.derivePath("m/44'/501'/0'/0'", seed);
+
+final storage = SecureStorageService(namespace: 'wallet');
+await storage.saveEncrypted('seed_phrase', mnemonic);
+await storage.saveEncrypted('private_key', base64Encode(derived.key));
+
+// Keep the private key out of any serialization
+Map<String, dynamic> toJson() => {
+      'publicKey': publicKey,
+      'walletId': walletId,
+      // privateKey intentionally omitted
+    };
+```
+
+### Salted Argon2id PIN hashing
+
+```dart
+import 'dart:convert';
+import 'package:cryptography/cryptography.dart';
+
+final _argon2 = Argon2id(
+  memory: 19456, // 19 MiB
+  parallelism: 1,
+  iterations: 2,
+  hashLength: 32,
+);
+
+// Returns "saltBase64:hashBase64"
+Future<String> hashPin(String pin) async {
+  final salt = SecretKeyData.random(length: 16).bytes;
+  final key = await _argon2.deriveKey(
+    secretKey: SecretKey(utf8.encode(pin)),
+    nonce: salt,
+  );
+  final hash = await key.extractBytes();
+  return '${base64Encode(salt)}:${base64Encode(hash)}';
+}
+
+Future<bool> verifyPin(String pin, String stored) async {
+  final parts = stored.split(':');
+  if (parts.length != 2) return false;
+  final salt = base64Decode(parts[0]);
+  final expected = base64Decode(parts[1]);
+  final key = await _argon2.deriveKey(
+    secretKey: SecretKey(utf8.encode(pin)),
+    nonce: salt,
+  );
+  final actual = await key.extractBytes();
+  return _constantTimeEquals(actual, expected);
+}
+
+bool _constantTimeEquals(List<int> a, List<int> b) {
+  if (a.length != b.length) return false;
+  var diff = 0;
+  for (var i = 0; i < a.length; i++) {
+    diff |= a[i] ^ b[i];
+  }
+  return diff == 0;
+}
+```
+
+### Secrets from environment, never hardcoded
+
+```dart
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+
+class AppConfig {
+  static String get rpcUrl =>
+      dotenv.env['SOLANA_RPC_URL'] ?? 'https://api.devnet.solana.com';
+}
+```
+
+```bash
+# .env, add this to .gitignore
+SOLANA_RPC_URL=https://your-project.helius-rpc.com/?api-key=SECRET
+```
+
+For CI or extra hardening, pass it at compile time so it is not sitting in APK assets:
+
+```bash
+flutter run --dart-define=SOLANA_RPC_URL=https://my-rpc.example.com
+```
+
+```dart
+const rpcUrl = String.fromEnvironment('SOLANA_RPC_URL');
+```
+
+### Biometric gate before revealing a seed phrase
+
+```dart
+import 'package:flutter/services.dart';
+import 'package:local_auth/local_auth.dart';
+import 'package:local_auth/error_codes.dart' as auth_error;
+
+final _localAuth = LocalAuthentication();
+
+Future<bool> authenticate(String reason) async {
+  try {
+    if (!await _localAuth.isDeviceSupported()) return false;
+    if (!await _localAuth.canCheckBiometrics) return false;
+    return _localAuth.authenticate(
+      localizedReason: reason,
+      options: const AuthenticationOptions(stickyAuth: true, biometricOnly: true),
+    );
+  } on PlatformException catch (e) {
+    if (e.code == auth_error.notAvailable || e.code == auth_error.notEnrolled) {
+      return false;
+    }
+    rethrow;
+  }
+}
+
+Future<List<String>?> exportSeedPhrase(
+  SecureStorageService storage,
+  String walletId,
+) async {
+  // Gate before decryption, not after
+  if (!await authenticate('Authenticate to view recovery phrase')) return null;
+  final mnemonic = await storage.getEncrypted('seed_$walletId');
+  return mnemonic?.split(' ');
+}
+```
+
+### Validate the RPC endpoint
+
+```dart
+import 'dart:io';
+
+Future<bool> validateEndpoint(String endpoint) async {
+  final uri = Uri.parse(endpoint);
+  if (uri.scheme != 'https') return false; // reject plaintext transport
+
+  const trusted = {
+    'api.mainnet-beta.solana.com',
+    'api.devnet.solana.com',
+  };
+  if (!trusted.contains(uri.host) && !await _isUserApprovedHost(uri.host)) {
+    return false;
+  }
+  try {
+    final client = HttpClient();
+    final req = await client.getUrl(Uri.parse('$endpoint/health'))
+        .timeout(const Duration(seconds: 10));
+    final res = await req.close();
+    return res.statusCode == 200;
+  } on HandshakeException {
+    return false; // invalid SSL certificate
+  }
+}
+```
+
+### Simulate before you send
+
+```dart
+import 'package:solana/solana.dart';
+
+// base64SignedTx is a fully signed transaction. Simulate first so a bad
+// transaction fails for free instead of burning fees.
+Future<String?> simulateThenSend(RpcClient rpc, String base64SignedTx) async {
+  final sim = await rpc.simulateTransaction(base64SignedTx);
+  if (sim.value.err != null) return null; // do not send
+  return rpc.sendTransaction(base64SignedTx);
+}
+```
+
+### Logout wipes everything
+
+```dart
+Future<void> logout() async {
+  await const FlutterSecureStorage().deleteAll();
+}
+```
+
+## Guidelines
+
+- DO generate key material with `Random.secure()`. Never derive entropy from a clock, a counter, or a device id you can guess.
+- DO use a fresh IV per encryption and store it with the ciphertext.
+- DO hash PINs with salted Argon2id (or scrypt or PBKDF2 with a high iteration count), store the salt, and compare in constant time.
+- DO put a biometric or PIN gate before decrypting key material, and decrypt only at the moment of use.
+- DO simulate transactions before sending.
+- DON'T store private keys or mnemonics in SharedPreferences or in plaintext anywhere.
+- DON'T put RPC URLs with API keys in source. Use a gitignored `.env` or `--dart-define`.
+- DON'T include the private key in `toJson()`, logs, `print`, `debugPrint`, or crash reporters.
+- DON'T reuse one encryption key or IV across wallets. Isolate per namespace.
+
+## Common Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| Keys recoverable from a rooted device | Secrets in SharedPreferences or plaintext | Use flutter_secure_storage with encryptedSharedPreferences, plus an AES layer |
+| Identical ciphertext for the same input | Fixed or zero IV reused every time | Use IV.fromSecureRandom(16) per encryption and store it with the ciphertext |
+| Encryption key is guessable | Entropy from DateTime or a counter | Generate the source bytes with Random.secure() |
+| PIN cracked from a leaked store | Bare unsalted SHA-256 of the PIN | Salted Argon2id, store the salt, constant time compare |
+| API key extracted from the APK | RPC URL hardcoded in source | Load from gitignored .env or pass with --dart-define |
+| Seed phrase shown without a check | No gate before decryption | Require local_auth before decrypting the mnemonic |
+| Funds lost to a failing transaction | Sent without simulating | simulateTransaction first, send only if err is null |
+| Man in the middle on RPC | Plaintext or untrusted endpoint | Reject non HTTPS, check the host against an approved list |
+
+## References
+
+- flutter_secure_storage: https://pub.dev/packages/flutter_secure_storage
+- encrypt: https://pub.dev/packages/encrypt
+- cryptography (Argon2id): https://pub.dev/packages/cryptography
+- local_auth: https://pub.dev/packages/local_auth
+- OWASP Mobile Top 10: https://owasp.org/www-project-mobile-top-10/
+- Related skills in this set: solana-mobile-wallet-adapter-flutter, building-solana-transactions-flutter, flutter-solana-seed-vault, solana-dart-sdk

--- a/skills/flutter-solana-zk-compression/SKILL.md
+++ b/skills/flutter-solana-zk-compression/SKILL.md
@@ -1,0 +1,543 @@
+---
+name: flutter-solana-zk-compression
+description: Build Flutter apps that compress, transfer, and decompress SOL and SPL tokens on Solana using the light_sdk Dart package and Light Protocol ZK compression. Use for compressed accounts and compressed tokens, the Light System Program and Compressed Token Program, fetching Groth16 validity proofs from the Photon indexer over Helius RPC, compressed address derivation, Borsh instruction encoding, and external wallet signing with progress tracking on mobile. Helius RPC required.
+license: MIT
+metadata:
+  author: Dominion Nwakanma (web3flutter.dev)
+  version: "1.0.0"
+tags:
+  - solana
+  - zk-compression
+  - light-protocol
+  - light-sdk
+  - compressed-tokens
+  - flutter
+  - dart
+  - helius
+  - photon
+  - groth16
+---
+
+# Flutter Solana ZK Compression with light_sdk
+
+## Overview
+
+Solana charges rent for every account stored on-chain. A single SPL token account costs about 0.002 SOL (roughly 2,039,280 lamports) in rent-exemption deposit. Airdropping to 100,000 wallets means around 200 SOL just in rent. For a consumer mobile app, that cost model is fatal.
+
+Light Protocol's ZK compression fixes this. Instead of storing each account's full data on-chain, you hash the data and store only the hash as a leaf in a Merkle tree. The actual data lives in the Solana ledger's transaction calldata and in an off-chain indexer. To modify a compressed account you supply the current data plus a zero-knowledge proof that it hashes to a leaf in the tree. The on-chain program verifies the proof, nullifies the old leaf, and appends a new one. Storing a compressed account costs about 100 lamports instead of about 2,000,000. That is the roughly 1000x reduction Light Protocol talks about.
+
+`light_sdk` is the Dart client for this system. It is the Dart port of Light Protocol's `@lightprotocol/stateless.js` TypeScript SDK. From your Flutter app you call `compress()` to move SOL or tokens into the compressed world, `transfer()` to send them, and `decompress()` to pull them back. Underneath, the SDK queries the Photon indexer, fetches Groth16 proofs from the prover, builds Light System Program and Compressed Token Program instructions, packs accounts, and Borsh-encodes instruction data.
+
+The package targets the `solana` Dart package's types. If you already use `Ed25519HDPublicKey`, `RpcClient`, and `Instruction` from `package:solana`, `light_sdk` plugs in without a parallel type system.
+
+Honest status. The package is pre-release beta (v0.1.0-beta.1), so pin it and expect minor API drift. ZK compression RPC is Helius-specific: the Photon indexer and prover are bundled behind the Helius endpoint, so a non-Helius RPC will fail compression calls. Validity proofs reference recent Merkle roots that expire after about 100 slots (roughly 40 seconds), so minimize the time between fetching a proof and submitting the transaction. The indexer lags 1 to 3 seconds behind chain, so do not query state immediately after a transaction.
+
+## Instructions
+
+1. Add `light_sdk: ^0.1.0-beta.1` and `solana: ^0.31.2` to pubspec.yaml. The SDK also pulls in `equatable` and `pointycastle` for Keccak256 hashing.
+2. Create one `Rpc` against a Helius endpoint with `Rpc.create('https://devnet.helius-rpc.com?api-key=YOUR_KEY')`. The same object serves standard Solana RPC (via `rpc.rpcClient`) and the Photon compression API.
+3. To compress SOL or tokens, fetch the active state tree with `rpc.getStateTreeInfos()` then `selectStateTreeInfo()`. Compression creates a new leaf and needs no validity proof.
+4. To transfer or decompress, fetch the owner's accounts with `getCompressedAccountsByOwner()` (or `getCompressedTokenAccountsByOwner()` for tokens), select inputs with `selectMinCompressedSolAccountsForTransfer()` or `selectMinCompressedTokenAccountsForTransfer()`, then call `rpc.getValidityProof()` with those hashes.
+5. Build the instruction with `LightSystemProgram` (SOL) or `CompressedTokenProgram` (tokens). Pass `proof.rootIndices` and `proof.compressedProof` for transfer and decompress.
+6. Add a compute unit limit: 1,000,000 for compress and decompress, 350,000 for SOL transfer, 600,000 for token transfer. Then fetch a recent blockhash, sign, send, and confirm.
+7. In production, do not use the convenience action functions (`compress`, `transfer`, `decompress`) because they require a local `Ed25519HDKeyPair`. Build the instruction with the program builders and sign with your external wallet (Privy, Phantom, Saga Seed Vault) instead.
+8. Emit progress between steps (preparing, proving, signing, sending, confirming) so the user sees movement during the 2 to 5 second proving step.
+9. After a transaction, refresh state with a retry loop using escalating delays (2s, 3s, 4s) because the indexer needs 1 to 3 seconds to catch up.
+10. When decompressing tokens, send to an SPL Associated Token Account (ATA), never a wallet address. Derive the ATA and create it in the same transaction if it does not exist.
+
+## Examples
+
+### Compress, transfer, and decompress SOL (local keypair)
+
+The convenience action functions are the fastest way to learn the flow. They take a local `Ed25519HDKeyPair` and run the full query, prove, build, sign, send, confirm pipeline.
+
+```dart
+import 'package:light_sdk/light_sdk.dart';
+import 'package:solana/solana.dart';
+
+Future<void> solRoundTrip() async {
+  final rpc = Rpc.create('https://devnet.helius-rpc.com?api-key=YOUR_KEY');
+  final wallet = await Ed25519HDKeyPair.random();
+  final recipient = Ed25519HDPublicKey.fromBase58(
+    'BPFLoaderUpgradeab1e11111111111111111111111',
+  );
+
+  // Compress 1 SOL. No validity proof: a new leaf is created, nothing consumed.
+  await compress(
+    rpc: rpc,
+    payer: wallet,
+    lamports: BigInt.from(1000000000),
+    toAddress: wallet.publicKey,
+  );
+
+  // Wait for the indexer before reading new compressed state.
+  await Future<void>.delayed(const Duration(seconds: 3));
+  final balance = await rpc.getCompressedBalanceByOwner(wallet.publicKey);
+  print('Compressed balance: $balance lamports');
+
+  // Transfer 0.1 SOL compressed. Consumes leaves, so a proof is fetched.
+  await transfer(
+    rpc: rpc,
+    payer: wallet,
+    owner: wallet,
+    lamports: BigInt.from(100000000),
+    toAddress: recipient,
+  );
+
+  // Decompress 0.5 SOL back to a regular wallet address.
+  await decompress(
+    rpc: rpc,
+    payer: wallet,
+    owner: wallet,
+    lamports: BigInt.from(500000000),
+    recipient: wallet.publicKey,
+  );
+}
+```
+
+### What transfer() does internally (mid-level pipeline)
+
+The action functions are recipes, not black boxes. This is the full body of `transfer()` so you can reproduce it with a custom signer, custom compute budget, or progress callbacks.
+
+```dart
+import 'package:light_sdk/light_sdk.dart';
+import 'package:solana/solana.dart';
+
+Future<String> transferManual({
+  required Rpc rpc,
+  required Ed25519HDKeyPair payer,
+  required Ed25519HDKeyPair owner,
+  required BigInt lamports,
+  required Ed25519HDPublicKey toAddress,
+}) async {
+  // 1. Fetch the owner's compressed accounts, paginated.
+  var accumulated = BigInt.zero;
+  final compressedAccounts = <CompressedAccount>[];
+  String? cursor;
+  while (accumulated < lamports) {
+    final batch = await rpc.getCompressedAccountsByOwner(
+      owner.publicKey,
+      cursor: cursor,
+      limit: 1000,
+    );
+    for (final account in batch.items) {
+      if (account.lamports > BigInt.zero) {
+        compressedAccounts.add(account);
+        accumulated += account.lamports;
+      }
+    }
+    cursor = batch.cursor;
+    if (batch.items.length < 1000) break;
+  }
+
+  // 2. Select the minimum set of inputs that covers the amount.
+  final (inputAccounts, _) =
+      selectMinCompressedSolAccountsForTransfer(compressedAccounts, lamports);
+
+  // 3. Fetch the validity proof for those inputs. Submit soon: roots expire.
+  final proof = await rpc.getValidityProof(
+    hashes: inputAccounts.map((a) => a.hash).toList(),
+  );
+
+  // 4. Build the Light System Program transfer instruction.
+  final instruction = LightSystemProgram.transfer(
+    payer: payer.publicKey,
+    inputCompressedAccounts: inputAccounts,
+    toAddress: toAddress,
+    lamports: lamports,
+    recentInputStateRootIndices: proof.rootIndices,
+    recentValidityProof: proof.compressedProof,
+  );
+
+  // 5. Build with compute budget, sign, send, confirm.
+  final signedTx = await buildAndSignTransaction(
+    rpc: rpc,
+    signer: payer,
+    instructions: [instruction],
+    computeUnitLimit: 350000,
+    additionalSigners: owner.publicKey == payer.publicKey ? const [] : [owner],
+  );
+  return sendAndConfirmTransaction(rpc: rpc, signedTx: signedTx);
+}
+```
+
+### Production: compress SPL tokens with an external wallet and progress
+
+In a real Flutter app the signer is an external wallet that signs asynchronously, so the action functions do not apply. Build the instruction with the program builder, sign with your wallet, and emit progress between steps.
+
+```dart
+import 'dart:convert';
+import 'dart:typed_data';
+import 'package:light_sdk/light_sdk.dart';
+import 'package:solana/solana.dart';
+
+enum CompressStep { preparing, proving, signing, sending, confirming }
+
+class LightProtocolService {
+  LightProtocolService({
+    required String heliusApiKey,
+    required this.walletPubkey,
+    required this.signMessage,
+  }) : _rpc = Rpc.create('https://mainnet.helius-rpc.com?api-key=$heliusApiKey');
+
+  final Rpc _rpc;
+  final Ed25519HDPublicKey walletPubkey;
+
+  // External wallet sign callback. For Privy: base64 encode, call the embedded
+  // wallet provider, base64 decode the returned signature.
+  final Future<Uint8List> Function(Uint8List message) signMessage;
+
+  Future<String> compressToken({
+    required String mint,
+    required BigInt amount,
+    required String sourceTokenAccount,
+    void Function(CompressStep step)? onProgress,
+  }) async {
+    onProgress?.call(CompressStep.preparing);
+
+    final mintPubkey = Ed25519HDPublicKey.fromBase58(mint);
+    final treeInfos = await _rpc.getStateTreeInfos();
+    final treeInfo = selectStateTreeInfo(treeInfos);
+    final tokenPoolInfo = await _getTokenPoolInfo(mintPubkey);
+
+    // Compress creates a new leaf, so no validity proof is required here.
+    final ix = CompressedTokenProgram.compress(
+      payer: walletPubkey,
+      owner: walletPubkey,
+      source: Ed25519HDPublicKey.fromBase58(sourceTokenAccount),
+      mint: mintPubkey,
+      amount: amount,
+      outputStateTreeInfo: treeInfo,
+      tokenPoolInfo: tokenPoolInfo,
+    );
+
+    onProgress?.call(CompressStep.signing);
+    final signedTx = await _buildAndSignWithExternalWallet(
+      [ix],
+      computeUnits: 1000000,
+    );
+
+    onProgress?.call(CompressStep.sending);
+    final signature = await _rpc.rpcClient.sendTransaction(signedTx);
+
+    onProgress?.call(CompressStep.confirming);
+    await _rpc.rpcClient.confirmTransaction(signature);
+    return signature;
+  }
+
+  Future<TokenPoolInfo> _getTokenPoolInfo(Ed25519HDPublicKey mint) async {
+    final poolPda = await CompressedTokenProgram.deriveTokenPoolPda(mint: mint);
+    final info = await _rpc.rpcClient.getAccountInfo(poolPda);
+    if (info == null) {
+      throw StateError('No token pool for $mint. Call createSplInterface first.');
+    }
+    return TokenPoolInfo(mint: mint, poolPda: poolPda);
+  }
+
+  // Assemble a transaction, hand the message bytes to the external wallet,
+  // attach the signature, and return the encoded transaction string.
+  Future<String> _buildAndSignWithExternalWallet(
+    List<Instruction> instructions, {
+    required int computeUnits,
+  }) async {
+    final bh = await _rpc.rpcClient.getLatestBlockhash();
+    final message = Message(
+      instructions: [
+        ComputeBudgetInstruction.setComputeUnitLimit(units: computeUnits),
+        ...instructions,
+      ],
+    );
+    final compiled = message.compile(
+      recentBlockhash: bh.value.blockhash,
+      feePayer: walletPubkey,
+    );
+
+    final signature = await signMessage(Uint8List.fromList(compiled.toByteArray()));
+    final tx = SignedTx(
+      signatures: [Signature(signature, publicKey: walletPubkey)],
+      compiledMessage: compiled,
+    );
+    return base64Encode(tx.toByteArray());
+  }
+}
+```
+
+### Production: transfer compressed tokens with full progress tracking
+
+A compressed token transfer has five phases. The proving step alone can take 2 to 5 seconds, so the UI must show progress or it feels broken.
+
+```dart
+import 'dart:typed_data';
+import 'package:light_sdk/light_sdk.dart';
+import 'package:solana/solana.dart';
+
+extension CompressedTokenTransfer on LightProtocolService {
+  Future<String> transferCompressedToken({
+    required String mint,
+    required BigInt amount,
+    required String recipientAddress,
+    void Function(CompressStep step)? onProgress,
+  }) async {
+    onProgress?.call(CompressStep.preparing);
+
+    final tokenAccounts = await rpc.getCompressedTokenAccountsByOwner(
+      walletPubkey,
+      mint: Ed25519HDPublicKey.fromBase58(mint),
+    );
+    final (selected, _) = selectMinCompressedTokenAccountsForTransfer(
+      tokenAccounts.items,
+      amount,
+      (a) => a.parsed.amount,
+    );
+
+    onProgress?.call(CompressStep.proving);
+    final hashes = selected.map((a) => a.compressedAccount.hash).toList();
+    final proof = await rpc.getValidityProof(hashes: hashes);
+
+    onProgress?.call(CompressStep.signing);
+    final ix = CompressedTokenProgram.transfer(
+      payer: walletPubkey,
+      inputCompressedTokenAccounts: selected,
+      toAddress: Ed25519HDPublicKey.fromBase58(recipientAddress),
+      amount: amount,
+      recentInputStateRootIndices: proof.rootIndices,
+      recentValidityProof: proof.compressedProof,
+    );
+    final signedTx =
+        await buildAndSignWithExternalWallet([ix], computeUnits: 600000);
+
+    onProgress?.call(CompressStep.sending);
+    final signature = await rpc.rpcClient.sendTransaction(signedTx);
+
+    onProgress?.call(CompressStep.confirming);
+    await rpc.rpcClient.confirmTransaction(signature);
+    return signature;
+  }
+}
+```
+
+The extension above assumes `rpc`, `walletPubkey`, and `buildAndSignWithExternalWallet` are exposed on the service. In the earlier example they are private; expose them or fold this method into the class body.
+
+### Production: decompress tokens to an ATA, creating it if missing
+
+Decompressing tokens requires an SPL ATA on the receiving end. If the ATA does not exist, the transaction fails. Create the ATA and decompress in one transaction so the user signs once.
+
+```dart
+import 'package:light_sdk/light_sdk.dart';
+import 'package:solana/solana.dart';
+
+Future<String> decompressTokenToAta({
+  required Rpc rpc,
+  required Ed25519HDPublicKey walletPubkey,
+  required String mint,
+  required BigInt amount,
+  required Future<String> Function(List<Instruction>, int computeUnits) signAndSend,
+}) async {
+  final mintPubkey = Ed25519HDPublicKey.fromBase58(mint);
+
+  // Derive the ATA and check whether it already exists.
+  final ata = await findAssociatedTokenAddress(
+    owner: walletPubkey,
+    mint: mintPubkey,
+  );
+  final ataInfo = await rpc.rpcClient.getAccountInfo(ata.toBase58());
+
+  final instructions = <Instruction>[];
+  if (ataInfo == null) {
+    instructions.add(
+      AssociatedTokenAccountInstruction.createAccount(
+        funder: walletPubkey,
+        address: ata,
+        owner: walletPubkey,
+        mint: mintPubkey,
+      ),
+    );
+  }
+
+  // Select inputs and fetch the proof.
+  final tokenAccounts = await rpc.getCompressedTokenAccountsByOwner(
+    walletPubkey,
+    mint: mintPubkey,
+  );
+  final (selected, _) = selectMinCompressedTokenAccountsForTransfer(
+    tokenAccounts.items,
+    amount,
+    (a) => a.parsed.amount,
+  );
+  final proof = await rpc.getValidityProof(
+    hashes: selected.map((a) => a.compressedAccount.hash).toList(),
+  );
+
+  final poolPda = await CompressedTokenProgram.deriveTokenPoolPda(mint: mintPubkey);
+  instructions.add(
+    CompressedTokenProgram.decompress(
+      payer: walletPubkey,
+      inputCompressedTokenAccounts: selected,
+      toAddress: ata, // ATA, never a wallet address
+      amount: amount,
+      recentInputStateRootIndices: proof.rootIndices,
+      recentValidityProof: proof.compressedProof,
+      tokenPoolInfo: TokenPoolInfo(mint: mintPubkey, poolPda: poolPda),
+    ),
+  );
+
+  return signAndSend(instructions, 1000000);
+}
+```
+
+### Create a token pool before compressing a new mint
+
+For major mainnet tokens (USDC and popular mints) the pool already exists. For a new or custom token, someone must create the SPL interface once before any compression works.
+
+```dart
+import 'package:light_sdk/light_sdk.dart';
+import 'package:solana/solana.dart';
+
+Future<Instruction> buildCreateTokenPool({
+  required Ed25519HDPublicKey feePayer,
+  required Ed25519HDPublicKey mint,
+}) {
+  return CompressedTokenProgram.createSplInterface(
+    feePayer: feePayer,
+    mint: mint,
+    tokenProgramId: Ed25519HDPublicKey.fromBase58(
+      'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+    ),
+  );
+}
+```
+
+### Derive a compressed address (V1 and V2)
+
+Most compressed accounts (SOL balances, fungible token balances) have no address: you scan them by owner. Accounts that need a stable identifier (user profile, game state, program config) use an address tree. Derivation uses Keccak256 truncated to the BN254 field, not Solana's SHA256 PDA scheme, so these addresses will not match Anchor PDAs.
+
+```dart
+import 'dart:typed_data';
+import 'package:light_sdk/light_sdk.dart';
+import 'package:solana/solana.dart';
+
+Future<void> deriveAddresses(Rpc rpc, Ed25519HDPublicKey programId) async {
+  final addressTree = await rpc.getAddressTreeInfoV2();
+  final userPubkey = Ed25519HDPublicKey.fromBase58(
+    '11111111111111111111111111111111',
+  );
+
+  // V1: Keccak256(programId + seeds), then Keccak256(tree + seed) with bump.
+  final seedV1 = deriveAddressSeed(
+    seeds: [
+      Uint8List.fromList('user_profile'.codeUnits),
+      Uint8List.fromList(userPubkey.bytes),
+    ],
+    programId: programId,
+  );
+  final addressV1 = deriveAddress(
+    seed: seedV1,
+    addressMerkleTreePubkey: addressTree.tree,
+  );
+
+  // V2: Keccak256(seeds + [255]), then Keccak256(seed + tree + programId + [255]).
+  final seedV2 = deriveAddressSeedV2([
+    Uint8List.fromList('user_profile'.codeUnits),
+    Uint8List.fromList(userPubkey.bytes),
+  ]);
+  final addressV2 = deriveAddressV2(
+    addressSeed: seedV2,
+    addressMerkleTreePubkey: addressTree.tree,
+    programId: programId,
+  );
+
+  print('V1 address: ${addressV1.toBase58()}');
+  print('V2 address: ${addressV2.toBase58()}');
+}
+```
+
+### Post-transaction refresh that handles indexer lag
+
+After a transaction the indexer needs 1 to 3 seconds. Retry with escalating delays instead of hammering it.
+
+```dart
+import 'package:light_sdk/light_sdk.dart';
+import 'package:solana/solana.dart';
+
+Future<List<CompressedTokenAccount>> refreshAfterTransaction({
+  required Rpc rpc,
+  required Ed25519HDPublicKey owner,
+  required int previousCount,
+  int retries = 3,
+}) async {
+  for (var i = 0; i < retries; i++) {
+    await Future<void>.delayed(Duration(seconds: 2 + i)); // 2s, 3s, 4s
+    final accounts = await rpc.getCompressedTokenAccountsByOwner(owner);
+    if (accounts.items.length != previousCount) {
+      return accounts.items;
+    }
+  }
+  // All retries exhausted: return last known state, show a refreshing hint.
+  final fallback = await rpc.getCompressedTokenAccountsByOwner(owner);
+  return fallback.items;
+}
+```
+
+### Decimal handling for token amounts
+
+SPL tokens have variable decimals (USDC is 6, SOL is 9, some are 0). Keep all on-chain math in `BigInt`. Convert to `double` only for display.
+
+```dart
+import 'dart:math';
+
+BigInt uiToOnChain(double uiAmount, int decimals) {
+  return BigInt.from((uiAmount * pow(10, decimals)).round());
+}
+
+double onChainToUi(BigInt onChainAmount, int decimals) {
+  return onChainAmount.toDouble() / pow(10, decimals);
+}
+
+void main() {
+  final onChain = uiToOnChain(100.5, 6); // BigInt 100500000
+  final ui = onChainToUi(onChain, 6);     // 100.5
+  print('$onChain then $ui');
+}
+```
+
+## Guidelines
+
+- DO use a Helius RPC endpoint with an API key. The Photon indexer and prover are Helius-specific extensions, so any other provider fails compression calls.
+- DO fetch the validity proof last and submit immediately. Roots expire after about 100 slots (roughly 40 seconds). Prepare everything else first, then call `getValidityProof()` and send back to back.
+- DO set a compute unit limit on every compressed transaction: 1,000,000 for compress and decompress, 350,000 for SOL transfer, 600,000 for token transfer, 400,000 for creating a token pool.
+- DO build instructions with `LightSystemProgram` or `CompressedTokenProgram` and sign with your external wallet in production. The action functions require a local `Ed25519HDKeyPair` and cannot use Privy, Phantom, or Seed Vault.
+- DO refresh state with escalating retry delays (2s, 3s, 4s) after a transaction. The indexer is 1 to 3 seconds behind chain.
+- DO use `BigInt` for all amounts and decimals. Floating point precision loss makes the amount mismatch what the compressed account holds, which fails the transaction.
+- DO let `packCompressedAccounts()` decide V1 versus V2 tree routing. V1 output accounts reference the tree pubkey, V2 reference the queue pubkey. The SDK checks `treeInfo.treeType`.
+- DO derive the SPL ATA and create it in the same transaction when decompressing tokens. Use `findAssociatedTokenAddress()` and check `getAccountInfo()` first.
+- DON'T query compressed state right after a transaction. You will get stale data because the indexer has not processed the event yet.
+- DON'T send compressed tokens with a regular SPL transfer. Use `CompressedTokenProgram.transfer()`, which consumes compressed token accounts and produces new ones (UTXO model with automatic change accounts).
+- DON'T decompress tokens to a wallet address. The `toAddress` must be an SPL token account, or the tokens can be lost.
+- DON'T hardcode state tree addresses. Trees roll over when full and the address changes. Use `getStateTreeInfos()` and `selectStateTreeInfo()`.
+- DON'T send parallel transfers to multiple recipients. They race on account selection and cause proof failures. Send sequentially: each transfer changes account state.
+- DON'T import internal `light_sdk/src` paths. Import `package:light_sdk/light_sdk.dart` only.
+- DON'T retry a failed proof immediately. The underlying state is likely unchanged. Re-fetch accounts, get a new proof, then retry.
+
+## Common Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| Compression RPC method not found | Endpoint is not Helius, so it has no Photon API | Use a Helius RPC endpoint with an API key |
+| Invalid proof or root not found | Root expired (over 40 seconds) or another tx changed the tree between fetch and submit | Re-fetch accounts, get a fresh proof, submit immediately |
+| Balance is stale right after compress | Indexer is 1 to 3 seconds behind chain | Retry with escalating delays (2s, 3s, 4s) before reading |
+| Compute budget exceeded | Compute unit limit too low for the operation | 1,000,000 for compress and decompress, 350,000 SOL transfer, 600,000 token transfer |
+| InsufficientBalanceException on transfer | Selected accounts total less than the requested amount | Check `getCompressedBalanceByOwner()` first, then transfer no more than that |
+| Token decompress fails or tokens lost | `toAddress` was a wallet address, not an SPL ATA | Derive the ATA, create it if missing, pass the ATA as `toAddress` |
+| Token compress fails with no pool | The mint has no token pool yet | Call `CompressedTokenProgram.createSplInterface()` once for that mint |
+| Queue full on devnet | No forester is emptying the nullifier queue for that tree | Use mainnet where Helius runs foresters, or wait for the forester |
+| Action function rejects external signer | `compress`, `transfer`, `decompress` require `Ed25519HDKeyPair` | Build with the program builders and sign with your wallet provider |
+| Derived address does not match an Anchor PDA | Compressed addresses use Keccak256 + BN254 truncation, not SHA256 | Expect different values, do not derive compressed addresses to match PDAs |
+
+## References
+
+- light_sdk on pub.dev: https://pub.dev/packages/light_sdk
+- Light Protocol ZK Compression docs: https://www.zkcompression.com/
+- Helius compression and DAS API: https://docs.helius.dev/compression-and-das-api/digital-asset-standard-das-api
+- TypeScript reference SDK (@lightprotocol/stateless.js): https://github.com/Lightprotocol/light-protocol
+- solana Dart SDK: https://pub.dev/packages/solana
+- Related skills in this set: solana-mobile-wallet-adapter-flutter, solana-dart-sdk, building-solana-transactions-flutter, flutter-solana-wallet-security

--- a/skills/integrating-jupiter-flutter/SKILL.md
+++ b/skills/integrating-jupiter-flutter/SKILL.md
@@ -1,0 +1,276 @@
+---
+name: integrating-jupiter-flutter
+description: Quote and execute Solana token swaps from Flutter and Dart using the Jupiter aggregator, the jupiter_aggregator Retrofit and Dio client, and the solana Dart SDK. Use to build QuoteRequestDto and JupiterSwapRequestDto calls, read multi-hop routePlan splits, pick slippage tiers, guard on priceImpactPct, fetch token USD prices from the Price API, decode and sign swap transactions with MWA or a local keypair, and proxy swaps through a backend. There is no pub.dev package, so vendor the source from the Espresso Cash monorepo.
+license: MIT
+metadata:
+  author: Dominion Nwakanma (web3flutter.dev)
+  version: "1.0.0"
+tags:
+  - solana
+  - jupiter
+  - dex
+  - swap
+  - defi
+  - flutter
+  - dart
+  - retrofit
+  - freezed
+  - price-api
+---
+
+# Integrating Jupiter Aggregator in Flutter
+
+## Overview
+
+Jupiter is the swap aggregator for Solana. It finds the best route across DEXes (Raydium, Orca, Phoenix, and more), returns a quote, and hands you a ready-to-sign transaction. The `jupiter_aggregator` package wraps the Jupiter swap API and the Price API with Retrofit-generated Dio clients and freezed DTOs.
+
+Two clients do the work. `JupiterAggregatorClient` handles the swap flow (quote and execute) against `quote-api.jup.ag/v6`. `JupiterPriceClient` fetches token USD prices against `api.jup.ag`. Every request and response is a freezed DTO, so the field names below are exact.
+
+There is no pub.dev package for Jupiter in Dart. You vendor the source from the Espresso Cash monorepo (`packages/jupiter_aggregator`) or rewrite the client against the same endpoint contracts. The package is internal (`publish_to: "none"`) and pinned at 0.0.5. It depends on `dio` ^5.4.0, `freezed_annotation` ^2.2.0, and `retrofit` ^4.0.3.
+
+## Instructions
+
+1. Vendor the `jupiter_aggregator` source into your repo from the Espresso Cash monorepo, or add it as a path or git dependency. There is no published package to pull from pub.dev.
+2. Construct `JupiterAggregatorClient()`. Pass `apiKey` for higher rate limits in production, or `baseUrl` to point at a proxy or self-hosted endpoint.
+3. Build a `QuoteRequestDto` with mints, `amount` in the input token's smallest unit, and `slippageBps`. Call `getQuote` to fetch a route.
+4. Read `quote.priceImpactPct` (a String) and warn the user before continuing if it is high.
+5. Build a `JupiterSwapRequestDto` with the user's public key and the entire `quoteResponse` object. Call `getSwapTransactions`.
+6. Decode `swap.swapTransaction` from base64. Sign with MWA (`signTransactions`) or a local `Ed25519HDKeyPair`. Send with the `solana` RpcClient.
+7. Fetch a fresh quote immediately before each swap. Quotes go stale fast and the transaction fails with an expired blockhash.
+8. For production, proxy swaps through your backend so the API key and fee logic stay server-side.
+
+## Examples
+
+### Quote, swap, sign, and send with a local keypair
+
+A full SOL to USDC swap signed by a local keypair. Note the fresh quote right before the swap request.
+
+```dart
+import 'dart:convert';
+import 'package:jupiter_aggregator/jupiter_aggregator.dart';
+import 'package:solana/solana.dart';
+import 'package:solana/encoder.dart';
+
+Future<String> swapSolToUsdc(Ed25519HDKeyPair wallet) async {
+  final jupiter = JupiterAggregatorClient();
+  final rpc = RpcClient('https://api.mainnet-beta.solana.com');
+
+  final quote = await jupiter.getQuote(QuoteRequestDto(
+    inputMint: 'So11111111111111111111111111111111111111112',  // wSOL
+    outputMint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', // USDC
+    amount: 1000000000,  // 1 SOL in lamports
+    slippageBps: 50,     // 0.5%
+  ));
+
+  final impact = double.tryParse(quote.priceImpactPct) ?? 0;
+  if (impact > 5.0) {
+    throw Exception('Price impact too high: $impact%');
+  }
+
+  final swap = await jupiter.getSwapTransactions(JupiterSwapRequestDto(
+    userPublicKey: wallet.address,
+    quoteResponse: quote,
+    wrapAndUnwrapSol: true,
+    dynamicComputeUnitLimit: true,
+    computeUnitPriceMicroLamports: 50000,
+  ));
+
+  // Decode the base64 transaction Jupiter built. It is unsigned: the
+  // compiled message and an empty signature slot for the fee payer.
+  final txBytes = base64Decode(swap.swapTransaction);
+  final tx = SignedTx.fromBytes(txBytes);
+
+  // Sign the compiled message with the local keypair and place the
+  // signature in the fee payer slot, then re-serialize.
+  final messageBytes = tx.compiledMessage.toByteArray().toList();
+  final signature = await wallet.sign(messageBytes);
+  final signed = SignedTx(
+    compiledMessage: tx.compiledMessage,
+    signatures: [signature],
+  );
+
+  final sig = await rpc.sendTransaction(
+    signed.encode(),
+    preflightCommitment: Commitment.confirmed,
+  );
+  return sig;
+}
+```
+
+### Full QuoteRequestDto with every parameter
+
+```dart
+import 'package:jupiter_aggregator/jupiter_aggregator.dart';
+
+const quote = QuoteRequestDto(
+  inputMint: 'So11111111111111111111111111111111111111112',
+  outputMint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+  amount: 1000000000,                // smallest unit of the input token
+  slippageBps: 50,                   // 0.5%, 1 bps = 0.01%
+  swapMode: SwapMode.exactIn,        // or SwapMode.exactOut
+  onlyDirectRoutes: false,           // true = single hop only
+  asLegacyTransaction: false,        // true = no versioned tx
+  autoSlippage: true,                // Jupiter computes optimal slippage
+  maxAutoSlippageBps: 300,           // cap auto slippage at 3%
+  platformFeeBps: 25,                // your platform fee (0.25%)
+  maxAccounts: 64,                   // transaction account limit
+  restrictIntermediateTokens: true,  // only well-known intermediaries
+);
+```
+
+`SwapMode.exactIn` means `amount` is the exact input and the output varies. This is the common case. `SwapMode.exactOut` means `amount` is the exact desired output and the input varies.
+
+### Reading a multi-hop route
+
+`quote.routePlan` is a `List<RoutePlan>`. Each hop carries its DEX label, mints, amounts, and fee.
+
+```dart
+import 'package:jupiter_aggregator/jupiter_aggregator.dart';
+
+void describeRoute(QuoteResponseDto quote) {
+  print('in:  ${quote.inAmount} of ${quote.inputMint}');
+  print('out: ${quote.outAmount} of ${quote.outputMint}');
+  print('min out after slippage: ${quote.otherAmountThreshold}');
+
+  for (final step in quote.routePlan) {
+    print('${step.percent}% via ${step.swapInfo.label}');
+    print('  ${step.swapInfo.inAmount} -> ${step.swapInfo.outAmount}');
+    print('  fee ${step.swapInfo.feeAmount} of ${step.swapInfo.feeMint}');
+    print('  pool ${step.swapInfo.ammKey}');
+  }
+}
+```
+
+### Fetching token prices with caching
+
+The Price client batches token IDs into one call (the `ids` param is comma-joined) and caches the result. It also handles Jupiter sometimes returning JSON as a raw string instead of a parsed object.
+
+```dart
+import 'package:jupiter_aggregator/jupiter_aggregator.dart';
+
+Future<double?> fetchSolPrice() async {
+  final priceClient = JupiterPriceClient();
+
+  final response = await priceClient.getPrice(PriceRequestDto(
+    ids: [
+      'So11111111111111111111111111111111111111112',  // SOL
+      'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', // USDC
+    ],
+  ));
+
+  // PriceDto.price is a nullable String. Null-check before parsing.
+  final raw = response.data['So11111111111111111111111111111111111111112']?.price;
+  if (raw == null) return null;
+  return double.tryParse(raw);
+}
+```
+
+For a cached client, annotate the Retrofit interface so repeat reads hit the Dio cache instead of hammering Jupiter on fast UI rebuilds.
+
+```dart
+import 'package:injectable/injectable.dart';
+import 'package:retrofit/retrofit.dart';
+import 'package:jupiter_aggregator/jupiter_aggregator.dart';
+
+@injectable
+@RestApi(baseUrl: 'https://api.jup.ag')
+abstract class CachedJupiterPriceClient {
+  @factoryMethod
+  factory CachedJupiterPriceClient(DioCacheClient client) =>
+      _CachedJupiterPriceClient(client.dio);
+
+  @GET('/price/v2')
+  @Extra({maxAgeOption: Duration(minutes: 1)})
+  Future<PriceResponseDto> getPrice(@Queries() PriceRequestDto request);
+}
+```
+
+### Backend-proxied swap with slippage tiers
+
+In production, proxy swaps through your backend to keep API keys server-side, add platform fees without exposing the logic, co-sign for gasless swaps, and rate-limit requests. These are the simplified proxy DTOs from Espresso Cash. `SwapSlippage` is a pre-defined tier enum, not a raw bps value.
+
+```dart
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'swap_route_dto.freezed.dart';
+
+@freezed
+class SwapRouteRequestDto with _$SwapRouteRequestDto {
+  const factory SwapRouteRequestDto({
+    required String inputToken,
+    required String outputToken,
+    required String amount,
+    required SwapSlippage slippage,   // pre-defined tier
+    required String userAccount,
+  }) = _SwapRouteRequestDto;
+}
+
+@freezed
+class SwapRouteResponseDto with _$SwapRouteResponseDto {
+  const factory SwapRouteResponseDto({
+    required String inAmount,
+    required String outAmount,
+    required String encodedTx,        // ready-to-sign transaction
+    required int feeInUsdc,
+  }) = _SwapRouteResponseDto;
+}
+```
+
+### JupiterSwapRequestDto with dynamic slippage
+
+```dart
+import 'package:jupiter_aggregator/jupiter_aggregator.dart';
+
+JupiterSwapRequestDto buildSwapRequest(
+  String walletAddress,
+  QuoteResponseDto quote,
+) {
+  return JupiterSwapRequestDto(
+    userPublicKey: walletAddress,
+    quoteResponse: quote,                  // pass the ENTIRE quote object
+    wrapAndUnwrapSol: true,                // auto wrap and unwrap SOL to wSOL
+    useSharedAccounts: true,               // Jupiter shared ATAs, saves rent
+    computeUnitPriceMicroLamports: 50000,  // priority fee
+    dynamicComputeUnitLimit: true,         // Jupiter sets optimal CU
+    dynamicSlippage: DynamicSlippage(      // server-side slippage optimization
+      minBps: 10,
+      maxBps: 300,
+    ),
+  );
+}
+```
+
+The response is a `JupiterSwapResponseDto`. Read `swap.swapTransaction` (base64 unsigned tx), `swap.lastValidBlockHeight` (block height expiry), `swap.prioritizationFeeLamports` (applied priority fee), and `swap.dynamicSlippageReport` (actual slippage if dynamic).
+
+## Guidelines
+
+- DO multiply by `10^decimals` for `amount`. 1 SOL is `1000000000`, 1 USDC is `1000000`. The field is in the input token's smallest unit, never whole tokens.
+- DO fetch a fresh quote immediately before `getSwapTransactions`. A stale quote fails with an expired blockhash.
+- DO pass the entire `quoteResponse` object to `JupiterSwapRequestDto`. The swap endpoint needs the full `QuoteResponseDto`, not hand-picked fields.
+- DO parse `priceImpactPct` to a double and warn above 1%, block or hard-warn above 5%.
+- DO null-check `PriceDto.price`. It is a `String?` and is null for unlisted tokens.
+- DO set a priority fee (`computeUnitPriceMicroLamports` or `prioritizationFeeLamports`) so swaps land.
+- DON'T expose your Jupiter API key in client code. Route swap calls through a backend proxy. Only price lookups should go direct from the client.
+- DON'T hardcode one slippage for all pairs. Use `autoSlippage: true` with `maxAutoSlippageBps`, or tune per token volatility.
+- DON'T cache quotes. Cache prices for at least a minute, but always re-quote before swapping.
+
+## Common Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| Output far smaller than expected | `amount` passed in whole tokens, not smallest unit | Multiply by `10^decimals`, 1 SOL = `1000000000` |
+| Transaction failed, blockhash expired | Reusing a stale quote for the swap | Fetch a fresh quote right before `getSwapTransactions` |
+| Swap endpoint rejects the request | Hand-picked fields sent instead of the full quote | Pass the entire `quoteResponse` object |
+| User loses value on an illiquid swap | `priceImpactPct` ignored | Parse the String to double, warn above 1%, block above 5% |
+| Swap fails on a volatile token | One hardcoded slippage for all pairs | Use `autoSlippage: true` with `maxAutoSlippageBps` |
+| Swap lands slowly or drops | No priority fee set | Set `computeUnitPriceMicroLamports` or `prioritizationFeeLamports` |
+| API key leaked from the app | Swap called directly from the client | Move swap calls behind a backend proxy |
+| Crash parsing a token price | `PriceDto.price` parsed as non-nullable | It is `String?`, null-check before `double.tryParse` |
+
+## References
+
+- jupiter_aggregator source (Espresso Cash monorepo): https://github.com/espresso-cash/espresso-cash-public/tree/master/packages/jupiter_aggregator
+- Jupiter developer docs: https://dev.jup.ag
+- solana Dart SDK: https://pub.dev/packages/solana
+- Re-verify the Jupiter endpoint hosts (`quote-api.jup.ag/v6` and `api.jup.ag/price/v2`) against current Jupiter docs before shipping. Jupiter has migrated its API surface and host names and versions can change.
+- Related skills in this set: solana-dart-sdk, building-solana-transactions-flutter, solana-mobile-wallet-adapter-flutter

--- a/skills/solana-dart-sdk/SKILL.md
+++ b/skills/solana-dart-sdk/SKILL.md
@@ -1,0 +1,348 @@
+---
+name: solana-dart-sdk
+description: Build Solana apps in Dart and Flutter with the solana package (v0.31.2 by Espresso Cash). Use to call RPC methods, derive keypairs from a mnemonic, create PDAs and ATAs, build and sign transactions, encode custom instruction data with ByteArray, add priority fees, and subscribe over WebSocket. The foundational SDK that other Dart Solana tooling depends on.
+license: MIT
+metadata:
+  author: Dominion Nwakanma (web3flutter.dev)
+  version: "1.0.0"
+tags:
+  - solana
+  - dart
+  - flutter
+  - rpc
+  - keypair
+  - transaction
+  - pda
+  - anchor
+  - compute-budget
+---
+
+# Solana Dart SDK (solana package)
+
+## Overview
+
+The `solana` package (v0.31.2, by Espresso Cash) is the most complete Dart SDK for Solana. Everything else in the Dart Solana ecosystem builds on it. It gives you:
+
+- `RpcClient`: all 52 JSON-RPC methods with proper Dart types.
+- `SolanaClient`: a high-level send-and-confirm orchestrator.
+- `Ed25519HDKeyPair` and `Ed25519HDPublicKey`: BIP39 mnemonic derivation and PDA creation.
+- `Message`, `Instruction`, `SignedTx`: transaction building and encoding.
+- `SubscriptionClient`: WebSocket subscriptions for accounts, logs, slots, and signatures.
+- Built-in program helpers: SystemProgram, Token, Token-2022, ATA, ComputeBudget, Memo, Stake.
+
+Pin it and treat it as the base layer for any Dart or Flutter Solana app.
+
+Package: https://pub.dev/packages/solana
+
+## Instructions
+
+1. Add `solana: ^0.31.0` to pubspec.yaml.
+2. Pick the right import. Use `package:solana/solana.dart` for everything, or `package:solana/encoder.dart` when you only build transactions (`Message`, `Instruction`, `SignedTx`, `AccountMeta`, `ByteArray`).
+3. Create a `SolanaClient` (rpcUrl plus websocketUrl) for high-level flows, or a bare `RpcClient` for direct RPC. For production, point both at a paid provider (Helius, QuickNode, Triton), not the public endpoint.
+4. Unwrap context-wrapped RPC results with `.value`. `getBalance` returns a `BalanceResult`, `getLatestBlockhash` returns a context result whose `.value` holds `blockhash` and `lastValidBlockHeight`.
+5. Derive keypairs with `Ed25519HDKeyPair.fromMnemonic(m, account: 0, change: 0)` for Phantom and Solflare compatibility (the standard `m/44'/501'/0'/0'` path).
+6. Build instructions, wrap them in a `Message`, then call `client.sendAndConfirmTransaction` with `Commitment.confirmed`. Drop to manual `compile` plus `SignedTx` only when you need control.
+7. For custom programs, build an `Instruction` with `AccountMeta.writeable` or `AccountMeta.readonly` and encode data with `ByteArray` (all integers little-endian).
+8. On mainnet, prepend `ComputeBudgetInstruction.setComputeUnitLimit` and `setComputeUnitPrice` to your instruction list.
+9. Watch confirmations or account changes with `SubscriptionClient`, and call `close()` when done.
+10. Wrap sends in a try and catch `JsonRpcException` to read `code`, `message`, and `transactionError`.
+
+## Examples
+
+### Connect, airdrop, and read a balance
+
+```dart
+import 'package:solana/solana.dart';
+
+Future<double> airdropAndReadBalance() async {
+  final client = SolanaClient(
+    rpcUrl: Uri.parse('https://api.devnet.solana.com'),
+    websocketUrl: Uri.parse('wss://api.devnet.solana.com'),
+  );
+
+  final wallet = await Ed25519HDKeyPair.random();
+  await client.rpcClient.requestAirdrop(wallet.address, lamportsPerSol);
+
+  // getBalance returns a BalanceResult, not an int. Unwrap with .value.
+  final result = await client.rpcClient.getBalance(wallet.address);
+  final lamports = result.value; // int
+  return lamports / lamportsPerSol;
+}
+```
+
+The `.value` unwrap applies to every context-wrapped RPC. The same shape covers `getLatestBlockhash`:
+
+```dart
+import 'package:solana/solana.dart';
+
+Future<({String blockhash, int lastValid})> latestBlockhash(RpcClient rpc) async {
+  final bh = await rpc.getLatestBlockhash();
+  return (
+    blockhash: bh.value.blockhash,        // String
+    lastValid: bh.value.lastValidBlockHeight, // int
+  );
+}
+```
+
+### Derive a wallet keypair from a mnemonic
+
+```dart
+import 'package:solana/solana.dart';
+
+Future<Ed25519HDKeyPair> importWallet(String mnemonic) async {
+  // account: 0, change: 0 produces m/44'/501'/0'/0', the standard Phantom path.
+  return Ed25519HDKeyPair.fromMnemonic(mnemonic, account: 0, change: 0);
+}
+```
+
+### Find a PDA and an ATA
+
+```dart
+import 'package:solana/solana.dart';
+
+Future<({Ed25519HDPublicKey pda, Ed25519HDPublicKey ata})> deriveAddresses({
+  required Ed25519HDPublicKey walletPubkey,
+  required Ed25519HDPublicKey mintPubkey,
+}) async {
+  final metaplexProgramId = Ed25519HDPublicKey.fromBase58(
+    'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
+  );
+
+  // findProgramAddress returns Ed25519HDPublicKey directly, not a (key, bump) tuple.
+  final pda = await Ed25519HDPublicKey.findProgramAddress(
+    seeds: [
+      'metadata'.codeUnits,
+      metaplexProgramId.bytes,
+      mintPubkey.bytes,
+    ],
+    programId: metaplexProgramId,
+  );
+
+  final ata = await findAssociatedTokenAddress(
+    owner: walletPubkey,
+    mint: mintPubkey,
+    tokenProgramType: TokenProgramType.tokenProgram, // or .token2022Program
+  );
+
+  return (pda: pda, ata: ata);
+}
+```
+
+### Send SOL with confirmation
+
+```dart
+import 'package:solana/solana.dart';
+
+Future<TransactionId> sendSol({
+  required SolanaClient client,
+  required Ed25519HDKeyPair sender,
+  required Ed25519HDPublicKey recipient,
+  required int lamports,
+}) async {
+  final message = Message.only(
+    SystemInstruction.transfer(
+      fundingAccount: sender.publicKey,
+      recipientAccount: recipient,
+      lamports: lamports,
+    ),
+  );
+  return client.sendAndConfirmTransaction(
+    message: message,
+    signers: [sender],
+    commitment: Commitment.confirmed,
+  );
+}
+```
+
+### Manual transaction build, sign, and raw send
+
+```dart
+import 'package:solana/solana.dart';
+import 'package:solana/encoder.dart';
+
+Future<TransactionId> manualTransfer({
+  required RpcClient rpc,
+  required Ed25519HDKeyPair sender,
+  required Ed25519HDPublicKey recipient,
+  required int lamports,
+}) async {
+  final transferIx = SystemInstruction.transfer(
+    fundingAccount: sender.publicKey,
+    recipientAccount: recipient,
+    lamports: lamports,
+  );
+  final message = Message(instructions: [transferIx]);
+
+  final bh = await rpc.getLatestBlockhash();
+  final compiled = message.compile(
+    recentBlockhash: bh.value.blockhash,
+    feePayer: sender.publicKey,
+  );
+
+  final signature = await sender.sign(compiled.toByteArray());
+  final signedTx = SignedTx(
+    signatures: [signature],
+    compiledMessage: compiled,
+  );
+
+  return rpc.sendTransaction(
+    signedTx.encode(), // base64
+    preflightCommitment: Commitment.confirmed,
+  );
+}
+```
+
+### Custom instruction with ByteArray data
+
+```dart
+import 'package:solana/solana.dart';
+import 'package:solana/encoder.dart';
+
+Instruction buildCustomIx({
+  required Ed25519HDPublicKey programId,
+  required Ed25519HDPublicKey accountA,
+  required Ed25519HDPublicKey accountB,
+  required Ed25519HDPublicKey accountC,
+}) {
+  return Instruction(
+    programId: programId,
+    accounts: [
+      AccountMeta.writeable(pubKey: accountA, isSigner: true),
+      AccountMeta.readonly(pubKey: accountB, isSigner: false),
+      AccountMeta.writeable(pubKey: accountC, isSigner: false),
+    ],
+    data: ByteArray.merge([
+      ByteArray.u8(0),            // instruction index
+      ByteArray.u64(1000000),     // amount argument (8 bytes LE)
+      ByteArray.fromString('hi'), // 8-byte length prefix + UTF-8 bytes
+    ]),
+  );
+}
+```
+
+### Priority fees for mainnet
+
+```dart
+import 'package:solana/solana.dart';
+import 'package:solana/encoder.dart';
+
+Message withPriorityFees(List<Instruction> instructions) {
+  final setLimit = ComputeBudgetInstruction.setComputeUnitLimit(units: 200000);
+  final setPrice = ComputeBudgetInstruction.setComputeUnitPrice(microLamports: 50000);
+
+  return Message(instructions: [
+    setLimit,
+    setPrice, // compute budget instructions go first
+    ...instructions,
+  ]);
+}
+```
+
+### WebSocket subscriptions
+
+```dart
+import 'package:solana/solana.dart';
+
+void watchTransaction(SolanaClient client, TransactionId txId) {
+  final sub = client.createSubscriptionClient();
+
+  sub.signatureSubscribe(txId).listen((status) {
+    if (status.err == null) print('Confirmed!');
+  });
+
+  // Remember to call sub.close() once you no longer need updates.
+}
+```
+
+### Anchor instruction with auto discriminator
+
+```dart
+import 'package:solana/solana.dart';
+import 'package:solana/anchor.dart';
+import 'package:solana/encoder.dart';
+
+Future<Instruction> anchorInitialize({
+  required Ed25519HDPublicKey programId,
+  required Ed25519HDPublicKey counterPda,
+  required Ed25519HDKeyPair wallet,
+}) async {
+  return AnchorInstruction.forMethod(
+    programId: programId,
+    method: 'initialize',
+    namespace: 'global', // always 'global' for instructions
+    accounts: [
+      AccountMeta.writeable(pubKey: counterPda, isSigner: false),
+      AccountMeta.writeable(pubKey: wallet.publicKey, isSigner: true),
+      AccountMeta.readonly(
+        pubKey: Ed25519HDPublicKey.fromBase58('11111111111111111111111111111111'),
+        isSigner: false,
+      ),
+    ],
+    arguments: ByteArray.u64(42), // args after the discriminator
+  );
+}
+```
+
+### Retry on a stale blockhash
+
+```dart
+import 'package:solana/solana.dart';
+import 'package:solana/encoder.dart';
+
+Future<TransactionId> sendWithRetry({
+  required RpcClient rpc,
+  required Message message,
+  required List<Ed25519HDKeyPair> signers,
+  int maxRetries = 3,
+}) async {
+  for (var i = 0; i < maxRetries; i++) {
+    try {
+      // signAndSendTransaction fetches a fresh blockhash each call.
+      return await rpc.signAndSendTransaction(message, signers);
+    } on JsonRpcException catch (e) {
+      if (e.message.contains('Blockhash not found') && i < maxRetries - 1) {
+        await Future<void>.delayed(const Duration(seconds: 2));
+        continue;
+      }
+      rethrow;
+    }
+  }
+  throw Exception('Transaction failed after $maxRetries retries');
+}
+```
+
+## Guidelines
+
+- DO unwrap context-wrapped RPC results with `.value`. `getBalance` returns a `BalanceResult`, `getLatestBlockhash` returns a context result, and passing the wrapper where an int or String is expected fails in non-obvious ways.
+- DO derive wallets with `account: 0, change: 0` so you get `m/44'/501'/0'/0'`. Omitting these or using wrong values derives a different address from the same mnemonic. This is the number one wallet import bug.
+- DO use `findProgramAddress` for PDAs. It returns an `Ed25519HDPublicKey` directly and finds the bump internally. Reach for `createProgramAddress` only when you already have an explicit bump.
+- DO match every `AccountMeta` against the program's IDL or source. Pick `.writeable()` or `.readonly()` and set `isSigner` exactly. Wrong values cause "failed to simulate transaction" with no useful message.
+- DO add `ComputeBudgetInstruction.setComputeUnitPrice` on mainnet, and put the compute budget instructions first in the list. 50,000 microLamports is a reasonable baseline, but check recent priority fee levels.
+- DO use a paid RPC provider in production. Public endpoints rate-limit at 40 requests per 10 seconds and will break under load.
+- DO use `Commitment.confirmed` or stronger for reads that follow a write. `Commitment.processed` can be rolled back.
+- DON'T forget `.value`. It is the most common context-unwrap mistake on `getBalance` and `getLatestBlockhash`.
+- DON'T copy TypeScript PDA patterns that expect a `(key, bump)` tuple. The Dart `findProgramAddress` returns only the key.
+- DON'T build a transaction early and send it late. Fetch the blockhash right before signing, or let `sendAndConfirmTransaction` handle it.
+- DON'T pass `Encoding.jsonParsed` to `getAccountInfo` for unknown programs. Use `Encoding.base64` and decode the raw account data yourself.
+
+## Common Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| Type error or wrong value from `getBalance` | Used the `BalanceResult` directly instead of the int | Read `result.value` |
+| Imported wallet has the wrong address | Derivation omitted `account: 0, change: 0` | Use `Ed25519HDKeyPair.fromMnemonic(m, account: 0, change: 0)` |
+| PDA code expects a bump tuple | Ported a TypeScript pattern | `findProgramAddress` returns only `Ed25519HDPublicKey`; bump is internal |
+| "failed to simulate transaction" with no detail | Wrong `isSigner` or writeable flag on an `AccountMeta` | Check each account against the program's IDL or source |
+| Transaction dropped during congestion | No priority fee on mainnet | Add `ComputeBudgetInstruction.setComputeUnitPrice()` first in the list |
+| "Blockhash not found" | Transaction built too early, sent too late | Fetch blockhash right before signing, or use `sendAndConfirmTransaction` |
+| App breaks under load | Hitting the public RPC rate limit (40 req/10s) | Use a paid provider (Helius, QuickNode, Triton) |
+| Stale read right after a write | Used `Commitment.processed` | Use `Commitment.confirmed` or stronger for post-write reads |
+| Garbage from `getAccountInfo` | `jsonParsed` used on an unknown program | Use `Encoding.base64` and decode manually |
+
+## References
+
+- solana package: https://pub.dev/packages/solana
+- solana source (Espresso Cash): https://github.com/espresso-cash/espresso-cash-public/tree/master/packages/solana
+- Solana JSON-RPC reference: https://solana.com/docs/rpc
+- Solana program derived addresses: https://solana.com/docs/core/pda
+- Related skills in this set: solana-mobile-wallet-adapter-flutter, building-solana-transactions-flutter, flutter-solana-wallet-security

--- a/skills/solana-mobile-wallet-adapter-flutter/SKILL.md
+++ b/skills/solana-mobile-wallet-adapter-flutter/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: solana-mobile-wallet-adapter-flutter
+description: Connect Flutter Android dApps to Solana wallets with the Mobile Wallet Adapter (MWA) protocol using solana_mobile_client and the solana Dart SDK. Use for MWA sessions, authorize and reauthorize, signing and sending transactions, off-chain message signing, and persisting auth tokens on Solana Mobile. Android only.
+license: MIT
+metadata:
+  author: Dominion Nwakanma (web3flutter.dev)
+  version: "1.0.0"
+tags:
+  - solana
+  - mobile-wallet-adapter
+  - mwa
+  - flutter
+  - dart
+  - android
+  - wallet-adapter
+  - transaction-signing
+  - solana-mobile
+---
+
+# Solana Mobile Wallet Adapter for Flutter dApps
+
+## Overview
+
+The Mobile Wallet Adapter (MWA) protocol is how a Flutter Android dApp gets a wallet app (Phantom, Solflare, Espresso Cash) to authorize the user and sign transactions. The `solana_mobile_client` package implements the dApp side. It opens a local session to the wallet, requests authorization, and submits payloads for signing or sign-and-send.
+
+Two classes do the work. `LocalAssociationScenario` manages the session (create, start, close). `MobileWalletAdapterClient` runs the RPC methods (authorize, sign, send).
+
+This is Android only. Apple blocks the inter-app patterns MWA relies on. For iOS use an embedded wallet or a deep-link flow. The package is at v0.1.1 (Espresso Cash), so pin it and expect minor API drift.
+
+## Instructions
+
+1. Add `solana_mobile_client: ^0.1.1` and `solana: ^0.31.0` to pubspec.yaml.
+2. Gate every MWA call behind `Platform.isAndroid`, then `LocalAssociationScenario.isAvailable()`.
+3. Create the session with `LocalAssociationScenario.create()`.
+4. Launch the wallet chooser fire-and-forget with `session.startActivityForResult(null).ignore()`.
+5. Await the client with `session.start()`.
+6. Inside a try block, call `reauthorize()` if a saved authToken exists for the same cluster, otherwise call `authorize()`. A null result means the user declined.
+7. To sign and submit, build a `SignedTx` with a 64-zero placeholder signature for the wallet pubkey, serialize with `toByteArray()`, then call `signAndSendTransactions`. To sign only, call `signTransactions` and submit the returned payloads yourself.
+8. Always call `session.close()` in a finally block.
+9. Persist authToken, publicKey, and cluster in flutter_secure_storage so you can reauthorize next time.
+
+## Examples
+
+### Connect, reauthorize, and persist
+
+From a production app. Reauthorize if the saved cluster matches, otherwise do a fresh authorize, then persist.
+
+```dart
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:solana/solana.dart';
+import 'package:solana/base58.dart';
+import 'package:solana_mobile_client/solana_mobile_client.dart';
+
+class MobileWalletService {
+  MobileWalletService(this._storage);
+  final FlutterSecureStorage _storage;
+
+  Future<AuthorizationResult?> connectWallet(String rpcUrl) async {
+    final session = await LocalAssociationScenario.create();
+    session.startActivityForResult(null).ignore();
+    final client = await session.start();
+
+    try {
+      final cluster = _clusterFromUrl(rpcUrl);
+      final savedToken = await _storage.read(key: 'mwa_auth_token');
+      final savedCluster = await _storage.read(key: 'mwa_cluster');
+
+      if (savedToken != null && savedCluster == cluster) {
+        final reauth = await client.reauthorize(
+          identityUri: Uri.parse('https://myapp.com'),
+          identityName: 'My App',
+          authToken: savedToken,
+        );
+        if (reauth != null) {
+          await _persistAuth(reauth, cluster);
+          return reauth;
+        }
+      }
+
+      final auth = await client.authorize(
+        identityUri: Uri.parse('https://myapp.com'),
+        identityName: 'My App',
+        cluster: cluster,
+      );
+      if (auth != null) {
+        await _persistAuth(auth, cluster);
+      }
+      return auth;
+    } finally {
+      await session.close();
+    }
+  }
+
+  Future<void> _persistAuth(AuthorizationResult auth, String cluster) async {
+    await _storage.write(key: 'mwa_auth_token', value: auth.authToken);
+    await _storage.write(
+      key: 'mwa_public_key',
+      value: Ed25519HDPublicKey(auth.publicKey).toBase58(),
+    );
+    await _storage.write(key: 'mwa_cluster', value: cluster);
+  }
+
+  String _clusterFromUrl(String url) {
+    if (url.contains('devnet')) return 'devnet';
+    if (url.contains('testnet')) return 'testnet';
+    return 'mainnet-beta';
+  }
+}
+```
+
+### Sign and send with local co-signers
+
+When the transaction has extra signers (for example a new account keypair). The wallet pubkey is the fee payer and gets a placeholder signature.
+
+```dart
+Future<String> signAndSendWithLocalSigners({
+  required MobileWalletAdapterClient client,
+  required Uint8List walletPubkey,
+  required RpcClient rpc,
+  required Message message,
+  required List<Ed25519HDKeyPair> localSigners,
+}) async {
+  final bh = await rpc.getLatestBlockhash();
+  final feePayer = Ed25519HDPublicKey(walletPubkey);
+  final compiled = message.compile(
+    recentBlockhash: bh.value.blockhash,
+    feePayer: feePayer,
+  );
+
+  final compiledBytes = compiled.toByteArray();
+  final signatures = <Signature>[
+    Signature(List.filled(64, 0), publicKey: feePayer), // placeholder for wallet
+  ];
+  for (final signer in localSigners) {
+    signatures.add(await signer.sign(compiledBytes));
+  }
+
+  final tx = SignedTx(signatures: signatures, compiledMessage: compiled);
+  final txBytes = Uint8List.fromList(tx.toByteArray());
+
+  final result = await client.signAndSendTransactions(transactions: [txBytes]);
+  return base58encode(result.signatures.first);
+}
+```
+
+### Off-chain message signing (sign in)
+
+```dart
+final result = await client.signMessages(
+  messages: [Uint8List.fromList(utf8.encode('Sign in to My dApp'))],
+  addresses: [auth.publicKey],
+);
+for (final signed in result.signedMessages) {
+  // signed.signatures is List<Uint8List>
+}
+```
+
+### Platform-aware entry point
+
+```dart
+import 'dart:io';
+
+Future<AuthorizationResult?> connect(MobileWalletService mwa, String rpcUrl) async {
+  if (Platform.isAndroid && await LocalAssociationScenario.isAvailable()) {
+    return mwa.connectWallet(rpcUrl);
+  }
+  // iOS or no MWA wallet installed: use an embedded wallet or deep-link flow instead.
+  return null;
+}
+```
+
+## Guidelines
+
+- DO close the session in a finally block. A leaked session leaves the wallet stuck until the user force-quits it.
+- DO use the wallet's `auth.publicKey` as the fee payer, never a local keypair.
+- DO clear the saved authToken when the cluster changes. Reauthorize fails across clusters.
+- DO null-check every authorize and reauthorize result. The user can decline at any time.
+- DON'T pass raw unsigned transaction bytes. Wallets expect a `SignedTx` with placeholder signatures, serialized with `toByteArray()`.
+- DON'T mix up the signing methods. `signTransactions` signs only and you submit. `signAndSendTransactions` signs and submits.
+- DON'T call MWA on iOS. Gate with `Platform.isAndroid` first.
+
+## Common Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| Wallet stuck, user must force-quit | Session not closed on the error path | Call `session.close()` in a finally block |
+| Reauthorize returns null | authToken is from a different cluster | Clear the stored token and call `authorize()` fresh |
+| Transaction signature verification failure | Passed raw tx bytes instead of a `SignedTx` | Build `SignedTx` with a 64-zero placeholder, then `toByteArray()` |
+| Transaction lands before the blockhash slot | `minContextSlot` not passed | Pass the slot from `getLatestBlockhash()` context |
+| App crashes after a connect attempt | Null authorize result was ignored | Always null-check auth results, the user can decline |
+| Wrong fee payer | Local keypair used as fee payer | Fee payer must be `auth.publicKey` from the wallet |
+
+## References
+
+- solana_mobile_client (Espresso Cash): https://github.com/espresso-cash/espresso-cash-public/tree/master/packages/solana_mobile_client
+- Solana Mobile and MWA docs: https://docs.solanamobile.com
+- solana Dart SDK: https://pub.dev/packages/solana
+- Related skills in this set: solana-dart-sdk, building-solana-transactions-flutter, flutter-solana-wallet-security, flutter-solana-seed-vault

--- a/skills/spl-token-dart/SKILL.md
+++ b/skills/spl-token-dart/SKILL.md
@@ -1,0 +1,326 @@
+---
+name: spl-token-dart
+description: Build SPL Token and Token-2022 flows in Flutter and Dart with the solana package. Use to create mints, derive and create associated token accounts, mint, transfer, burn, freeze, close accounts, manage authorities, and read parsed token balances. Covers both the high-level SolanaClient extensions and the low-level TokenInstruction factories, plus Token-2022 (Token Extensions).
+license: MIT
+metadata:
+  author: Dominion Nwakanma (web3flutter.dev)
+  version: "1.0.0"
+tags:
+  - solana
+  - spl-token
+  - token-2022
+  - token-extensions
+  - flutter
+  - dart
+  - mint
+  - associated-token-account
+  - nft-and-tokens
+---
+
+# SPL Token Operations for Dart and Flutter
+
+## Overview
+
+SPL token support is built into the `solana` Dart package. There is no separate package to add. Import `package:solana/solana.dart` and you have everything for mints, token accounts, transfers, mints, burns, and authority management.
+
+The package gives you two API layers:
+
+1. Low-level `TokenInstruction`: factory constructors that produce individual `Instruction` objects for every Token Program operation. Use these when you compose multiple instructions into one transaction.
+2. High-level `SolanaClient` extensions: convenience methods on `SolanaClient` that build, sign, and send a complete transaction for you.
+
+Both layers target the original Token Program and Token-2022 through the `TokenProgramType` enum. The original program is the default. Pass `TokenProgramType.token2022Program` to work with Token Extensions mints.
+
+One rule runs through everything here. Token amounts are always in the smallest unit, never in display units. For a 6 decimal token, 1 token is `1000000`. Get this wrong and you will mint or transfer a million times too much or too little.
+
+## Instructions
+
+1. Add `solana: ^0.31.2` to pubspec.yaml. SPL token support ships inside it.
+2. Create a `SolanaClient` with an `rpcUrl` and a `websocketUrl` for the cluster you target.
+3. To create a token, call `client.initializeMint(mintAuthority:, decimals:)`. It returns a `Mint` with the new mint address.
+4. Before you can hold or receive a token, create an associated token account (ATA) with `client.createAssociatedTokenAccount(mint:, funder:, owner:)`. The `funder` pays rent and signs. `owner` defaults to the funder.
+5. To put supply into circulation, call `client.mintTo(mint:, destination:, amount:, authority:)`. The `destination` must be an initialized token account, and `amount` is in smallest units.
+6. To move tokens, call `client.transferSplToken(mint:, destination:, amount:, owner:)`. The `destination` is the recipient's wallet (owner) address, not their ATA. The method resolves both ATAs for you.
+7. Always check `client.hasAssociatedTokenAccount(owner:, mint:)` before a transfer to a new recipient, and create the ATA if it is missing, otherwise the transfer throws.
+8. For Token-2022 mints, pass `tokenProgramType: TokenProgramType.token2022Program` on every call that touches that mint.
+9. When you need custom composition (create plus initialize in one transaction, set authority, close account), drop to `TokenInstruction` factories and send them with `client.sendAndConfirmTransaction`.
+
+## Examples
+
+### End to end: create a mint, create an ATA, then transfer
+
+This is the full happy path with the real `solana` package API. It creates a 6 decimal mint, creates an ATA for the authority, mints supply, creates an ATA for the recipient if missing, and transfers. Every method here is a `SolanaClient` extension from the source.
+
+```dart
+import 'package:solana/solana.dart';
+
+Future<void> createMintAtaAndTransfer() async {
+  final client = SolanaClient(
+    rpcUrl: Uri.parse('https://api.devnet.solana.com'),
+    websocketUrl: Uri.parse('wss://api.devnet.solana.com'),
+  );
+
+  // Fund these wallets with devnet SOL before running.
+  final authority = await Ed25519HDKeyPair.random();
+  final recipient = await Ed25519HDKeyPair.random();
+
+  const decimals = 6;
+  const oneToken = 1000000; // 10^6 for a 6 decimal token
+
+  // 1. Create a new mint. authority signs and pays.
+  final mint = await client.initializeMint(
+    mintAuthority: authority,
+    decimals: decimals,
+  );
+
+  // 2. Create the authority's ATA so it can hold the supply.
+  final authorityAta = await client.createAssociatedTokenAccount(
+    mint: mint.address,
+    funder: authority,
+  );
+
+  // 3. Mint 1000 tokens into the authority's ATA. amount is in smallest units.
+  await client.mintTo(
+    mint: mint.address,
+    destination: Ed25519HDPublicKey.fromBase58(authorityAta.pubkey),
+    amount: 1000 * oneToken,
+    authority: authority,
+  );
+
+  // 4. Make sure the recipient has an ATA, create it if not.
+  final recipientHasAta = await client.hasAssociatedTokenAccount(
+    owner: recipient.publicKey,
+    mint: mint.address,
+  );
+  if (!recipientHasAta) {
+    await client.createAssociatedTokenAccount(
+      mint: mint.address,
+      funder: authority, // authority pays the rent here
+      owner: recipient.publicKey,
+    );
+  }
+
+  // 5. Transfer 250 tokens. destination is the recipient WALLET, not the ATA.
+  await client.transferSplToken(
+    mint: mint.address,
+    destination: recipient.publicKey,
+    amount: 250 * oneToken,
+    owner: authority,
+  );
+}
+```
+
+### Read a wallet's parsed token balance
+
+Query token accounts by owner and read the parsed amount and decimals straight off the RPC response.
+
+```dart
+import 'package:solana/solana.dart';
+
+Future<void> printTokenBalance({
+  required SolanaClient client,
+  required String walletAddress,
+  required String mintAddress,
+}) async {
+  final accounts = await client.rpcClient.getTokenAccountsByOwner(
+    walletAddress,
+    TokenAccountsFilter.byMint(mintAddress),
+    encoding: Encoding.jsonParsed,
+  );
+
+  if (accounts.value.isEmpty) {
+    print('No token account for this mint');
+    return;
+  }
+
+  final data =
+      accounts.value.first.account.data as ParsedSplTokenProgramAccountData;
+  final info = (data.parsed as TokenAccountData).info;
+
+  print('raw amount: ${info.tokenAmount.amount}');
+  print('decimals: ${info.tokenAmount.decimals}');
+  print('mint: ${info.mint}');
+  print('owner: ${info.owner}');
+}
+```
+
+### Derive an ATA address off chain
+
+You do not need a network call to know where an ATA lives. It is a PDA derived from the owner, the token program, and the mint.
+
+```dart
+import 'package:solana/solana.dart';
+
+Future<Ed25519HDPublicKey> ataFor({
+  required Ed25519HDPublicKey owner,
+  required Ed25519HDPublicKey mint,
+}) {
+  return findAssociatedTokenAddress(
+    owner: owner,
+    mint: mint,
+    tokenProgramType: TokenProgramType.tokenProgram,
+  );
+}
+```
+
+### Compose with low-level instructions: create and initialize a mint in one transaction
+
+When the high-level helper is not enough, build the instructions yourself. This creates the mint account and initializes it in a single transaction.
+
+```dart
+import 'package:solana/solana.dart';
+import 'package:solana/encoder.dart';
+
+Future<void> createMintLowLevel({
+  required SolanaClient client,
+  required Ed25519HDKeyPair payer,
+  required Ed25519HDKeyPair mintKeypair,
+  required Ed25519HDPublicKey mintAuthority,
+}) async {
+  final rent = await client.rpcClient.getMinimumBalanceForRentExemption(
+    TokenProgram.neededMintAccountSpace,
+  );
+
+  final instructions = TokenInstruction.createAccountAndInitializeMint(
+    mint: mintKeypair.publicKey,
+    mintAuthority: mintAuthority,
+    rent: rent,
+    space: TokenProgram.neededMintAccountSpace,
+    decimals: 6,
+  );
+
+  final message = Message(instructions: instructions);
+  await client.sendAndConfirmTransaction(
+    message: message,
+    signers: [payer, mintKeypair],
+    commitment: Commitment.confirmed,
+  );
+}
+```
+
+### Transfer mint authority (or revoke it)
+
+`setAuthority` changes or removes an authority. Pass `null` as `newAuthority` to revoke permanently, which is how you make a fixed supply token.
+
+```dart
+import 'package:solana/solana.dart';
+import 'package:solana/encoder.dart';
+
+Future<void> revokeMintAuthority({
+  required SolanaClient client,
+  required Ed25519HDKeyPair currentAuthority,
+  required Ed25519HDPublicKey mint,
+}) async {
+  final ix = TokenInstruction.setAuthority(
+    mintOrAccount: mint,
+    currentAuthority: currentAuthority.publicKey,
+    authorityType: AuthorityType.mintTokens,
+    newAuthority: null, // null revokes the authority forever
+  );
+
+  final message = Message.only(ix);
+  await client.sendAndConfirmTransaction(
+    message: message,
+    signers: [currentAuthority],
+    commitment: Commitment.confirmed,
+  );
+}
+```
+
+### Close an empty token account and reclaim rent
+
+A zero balance ATA still holds rent. Close it to recover roughly 0.002 SOL.
+
+```dart
+import 'package:solana/solana.dart';
+import 'package:solana/encoder.dart';
+
+Future<void> closeEmptyAta({
+  required SolanaClient client,
+  required Ed25519HDKeyPair owner,
+  required Ed25519HDPublicKey emptyAta,
+}) async {
+  final ix = TokenInstruction.closeAccount(
+    accountToClose: emptyAta,
+    destination: owner.publicKey, // reclaimed SOL goes here
+    owner: owner.publicKey,
+  );
+
+  final message = Message.only(ix);
+  await client.sendAndConfirmTransaction(
+    message: message,
+    signers: [owner],
+    commitment: Commitment.confirmed,
+  );
+}
+```
+
+### Token-2022 (Token Extensions)
+
+Token-2022 is a separate program that extends the original Token Program. Use `TokenProgramType.token2022Program` on every call that touches a Token-2022 mint. The same `SolanaClient` extensions work, you just change the program type.
+
+```dart
+import 'package:solana/solana.dart';
+
+Future<void> token2022Ata({
+  required SolanaClient client,
+  required Ed25519HDKeyPair wallet,
+  required Ed25519HDPublicKey token2022Mint,
+}) async {
+  await client.createAssociatedTokenAccount(
+    mint: token2022Mint,
+    funder: wallet,
+    tokenProgramType: TokenProgramType.token2022Program,
+  );
+}
+```
+
+The `Token2022Program` class exposes instruction indexes for the extensions, for example `initializeMintCloseAuthorityInstructionIndex`, `transferFeeExtensionInstructionIndex`, `interestBearingMintExtensionInstructionIndex`, `metadataPointerExtensionInstructionIndex`, and more. The `ExtensionType` enum names the supported extensions:
+
+| Extension | Value | Purpose |
+|-----------|-------|---------|
+| `transferFeeConfig` | 1 | Automatic transfer fees |
+| `mintCloseAuthority` | 3 | Allow the mint account to be closed |
+| `defaultAccountState` | 6 | Accounts start frozen |
+| `immutableOwner` | 7 | Account owner cannot change |
+| `memoTransfer` | 8 | Require a memo on transfers |
+| `nonTransferable` | 9 | Soulbound tokens |
+| `interestBearingConfig` | 10 | Interest accrual |
+| `permanentDelegate` | 12 | Permanent delegate authority |
+| `transferHook` | 14 | Custom transfer logic |
+| `metadataPointer` | 18 | Pointer to a metadata account |
+| `tokenMetadata` | 19 | On-chain metadata |
+
+## Guidelines
+
+- DO express every `amount` in the smallest unit. Multiply display units by `10^decimals`. For 6 decimal USDC, 1 USDC is `1000000`.
+- DO pass the recipient's wallet (owner) address as `destination` in `transferSplToken`. The method resolves the ATAs internally.
+- DO call `hasAssociatedTokenAccount` before transferring to a new recipient, and create the ATA if it is missing.
+- DO create the destination token account before you call `mintTo`. The destination must already be initialized.
+- DO match the `TokenProgramType` to the mint. A Token-2022 mint needs `TokenProgramType.token2022Program` on every related call.
+- DO wrap `getMint` in a try/catch. It throws `TokenAccountNotFoundException` when the mint does not exist or the address is wrong.
+- DO close zero balance ATAs with `closeAccount` to reclaim rent.
+- DON'T pass an ATA address as `destination` in `transferSplToken`. Pass the owner wallet address.
+- DON'T pass display amounts. There is no implicit decimal scaling.
+- DON'T use `TokenProgramType.tokenProgram` for a Token-2022 mint, the program owner will not match and the call fails.
+- DON'T try to burn native (wrapped) SOL. Use `closeAccount` to recover SOL from a wrapped SOL account instead.
+
+## Common Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| Minted or transferred the wrong magnitude | `amount` passed in token units, not smallest units | Multiply by `10^decimals`, for 6 decimals 1 token is `1000000` |
+| `NoAssociatedTokenAccountException` on transfer | Sender or recipient ATA does not exist | Call `hasAssociatedTokenAccount` first, create with `createAssociatedTokenAccount` if missing |
+| Transfer sends to the wrong place or fails | ATA address passed as `destination` in `transferSplToken` | Pass the owner wallet address, the method resolves ATAs |
+| `mintTo` fails with an uninitialized account | Destination token account was never created | Create the ATA with `createAssociatedTokenAccount` before minting |
+| Token-2022 call fails with a program mismatch | Used `TokenProgramType.tokenProgram` for a Token-2022 mint | Pass `TokenProgramType.token2022Program` on every call for that mint |
+| `TokenAccountNotFoundException` from `getMint` | Mint does not exist yet or the address is wrong | Wrap in try/catch and verify the mint address |
+| Burn of wrapped SOL fails | Native SOL token burns are not supported | Use `closeAccount` to reclaim SOL from the wrapped SOL account |
+| Rent slowly drains across many empty ATAs | Zero balance accounts left open | Call `closeAccount` on empty ATAs to recover roughly 0.002 SOL each |
+
+## References
+
+- solana Dart SDK: https://pub.dev/packages/solana
+- SPL Token Program: https://spl.solana.com/token
+- Token-2022 (Token Extensions): https://spl.solana.com/token-2022
+- Associated Token Account Program: https://spl.solana.com/associated-token-account
+- Related skills in this set: solana-dart-sdk, building-solana-transactions-flutter, solana-mobile-wallet-adapter-flutter


### PR DESCRIPTION
First Flutter and Dart skills for the directory. They cover Solana mobile and Dart work the current TypeScript skills do not.

Client and core:
- solana-dart-sdk
- solana-mobile-wallet-adapter-flutter (Mobile Wallet Adapter)
- coral-xyz-anchor-dart (Anchor client for Dart)
- building-solana-transactions-flutter

Tokens and NFTs:
- spl-token-dart
- flutter-solana-metaplex-nft

DeFi, infra, security:
- integrating-jupiter-flutter
- flutter-solana-zk-compression (Light Protocol)
- flutter-solana-domain-resolution (AllDomains ANS)
- flutter-solana-wallet-security

Several map to IDEAS.md asks (mobile-wallet-adapter, transaction-building, spl-token, nft-creation) for the Dart and Flutter side. Code is pinned to current pub.dev versions. License MIT.
