### PR TITLE
feat: add jito-bundles skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -76,6 +76,12 @@
       "category": "Frontend"
     },
     {
+      "name": "jito-bundles",
+      "source": "./skills/jito-bundles",
+      "description": "Land atomic, all-or-nothing transaction bundles on Solana via the Jito Block Engine with @solana/web3.js — fetch tip accounts, size the tip from the tip-floor feed, build versioned transactions, send via JSON-RPC, and poll bundle status to confirmation. Use when an agent needs MEV protection, guaranteed transaction ordering, or several transactions to execute together in one slot or not at all.",
+      "category": "Client Development"
+    },
+    {
       "name": "jupiter",
       "source": "./skills/jupiter",
       "description": "Jupiter APIs — Ultra Swap, Lend, Perps, Trigger, Recurring, Tokens, Price, Portfolio, routing, and production integration patterns",

--- a/skills/jito-bundles/SKILL.md
+++ b/skills/jito-bundles/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: jito-bundles
+description: Land atomic, all-or-nothing transaction bundles on Solana via the Jito Block Engine with @solana/web3.js — fetch tip accounts, size the tip from the tip-floor feed, build versioned transactions, send via JSON-RPC, and poll bundle status to confirmation. Use when an agent needs MEV protection, guaranteed transaction ordering, or several transactions to execute together in one slot or not at all.
+---
+
+# Jito Bundles Development Guide
+
+Land **bundles** — ordered groups of up to 5 transactions that execute
+**atomically in a single slot** — on Solana through the Jito Block Engine. Bundles
+give you guaranteed ordering, all-or-nothing execution, and MEV protection that
+ordinary `sendTransaction` cannot.
+
+## Overview
+
+A bundle is a list of **1–5 fully-signed transactions** submitted together. The
+Jito Block Engine either lands **all of them, in order, in the same slot**, or
+**none** of them. To be considered, a bundle must include a **tip** — a SOL
+transfer to one of Jito's tip accounts — and the tip (not the Solana priority
+fee) is what wins the auction.
+
+Use this skill when you need to:
+- execute multiple dependent transactions atomically (e.g. setup → action → settle),
+- guarantee transaction ordering within a slot,
+- protect a transaction from front-running / sandwiching (MEV protection),
+- or improve landing odds during congestion by paying a Jito tip.
+
+The Block Engine is **plain JSON-RPC over HTTPS** — for `@solana/web3.js` v1.x you
+need **no Jito SDK**, just `fetch`.
+
+## Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `sendBundle` | `/api/v1/bundles` | submit 1–5 signed txns |
+| `getInflightBundleStatuses` | `/api/v1/getInflightBundleStatuses` | fast status (5-min window) |
+| `getBundleStatuses` | `/api/v1/getBundleStatuses` | on-chain confirmation + signatures |
+| `getTipAccounts` | `/api/v1/getTipAccounts` | the 8 tip accounts |
+
+Base URL `https://mainnet.block-engine.jito.wtf` (regional hosts:
+`amsterdam`, `dublin`, `frankfurt`, `london`, `ny`, `slc`, `singapore`, `tokyo`
+— `.mainnet.block-engine.jito.wtf`). Full reference: `resources/block-engine-reference.md`.
+
+## Quick Start
+
+### Installation
+
+```bash
+npm install @solana/web3.js   # v1.95+ for stable VersionedTransaction support. No Jito SDK needed.
+```
+
+### Send a bundle (raw JSON-RPC)
+
+```ts
+import { Connection, SystemProgram, PublicKey } from "@solana/web3.js";
+import {
+  getTipAccounts, pickTipAccount, fetchTipLamports,
+  buildV0Tx, encodeBase64, jitoRpc, tipInstruction, waitForBundle,
+} from "./examples/_shared/util";
+
+const connection = new Connection("https://api.mainnet-beta.solana.com", "confirmed");
+
+// 1. tip account (random of 8) + competitive tip (tip-floor-derived, SOL->lamports handled)
+const tipAccount = pickTipAccount(await getTipAccounts());
+const tipLamports = await fetchTipLamports();
+
+// 2. all txns share ONE recent blockhash (single-slot execution)
+const { blockhash } = await connection.getLatestBlockhash("confirmed");
+const work = buildV0Tx(payer.publicKey, blockhash, [/* your instructions */], [payer]);
+const last = buildV0Tx(payer.publicKey, blockhash,
+  [/* more instructions */, tipInstruction(payer.publicKey, tipAccount, tipLamports)], [payer]);
+
+// 3. base64-encode and send — {encoding:'base64'} is REQUIRED (legacy default is base58)
+const bundleId = await jitoRpc<string>("sendBundle", [[work, last].map(encodeBase64), { encoding: "base64" }]);
+
+// 4. a bundle_id means RECEIVED, not LANDED — poll until terminal
+const status = await waitForBundle(bundleId);
+console.log("landed in slot", status.slot, status.confirmation_status, status.transactions);
+```
+
+See `templates/send-jito-bundle.ts` for a reusable `sendJitoBundle()` that does
+tip injection, encoding, sending, and polling in one call.
+
+## Core Features
+
+### Atomic, ordered execution
+Up to 5 transactions land **all-or-nothing**, **in order**, in **one slot**. If
+any transaction fails, the entire bundle is rejected and nothing commits. Budget
+one of the 5 slots for the tip if you tip in a standalone transaction.
+
+### Tips (how bundles win)
+The tip is a `SystemProgram.transfer` to a tip account, in the **last**
+transaction (ideally folded into your real work so a failed strategy never pays).
+Size it from the **tip-floor feed** — and remember those values are in **SOL**,
+so convert with `× LAMPORTS_PER_SOL`. For `sendBundle`, **only the tip** decides
+landing; the priority fee does not. Details: `resources/tip-accounts.md`.
+
+### Confirmation
+`getInflightBundleStatuses` gives a fast `Pending|Landed|Failed|Invalid` within a
+5-minute window; once `Landed`, `getBundleStatuses` returns the real on-chain
+signatures, slot, and `confirmation_status`.
+
+### Examples
+- `examples/send-bundle/` — two transfers, atomic, send + confirm.
+- `examples/tip-floor-and-confirm/` — size the tip from the live feed and confirm to finality.
+
+## Best Practices
+
+- **Always pass `{ encoding: "base64" }`** to `sendBundle` — the default is the deprecated base58.
+- **Never trust the `bundle_id` as success** — poll status to a terminal state.
+- **Fetch tip accounts at runtime** (`getTipAccounts`) and pick one **at random** to avoid write-lock contention.
+- **Size the tip from `tip_floor`** (50th–75th percentile), not the 1,000-lamport minimum, and convert **SOL → lamports**.
+- **Build & sign as late as possible** — blockhashes expire in ~60–90s; a stale one means the bundle won't land.
+- **Respect the rate limit** — 1 req/sec per IP per region; sleep ≥1s in poll loops or use regional hosts.
+- **Fold the tip into a real transaction** rather than a standalone tip tx (saves a slot, reduces "uncle bandit" exposure).
+
+## Common Errors
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Bundle "succeeds" but never lands | `bundle_id` ≠ landed | poll `getInflightBundleStatuses` / `getBundleStatuses` |
+| Stays `Pending` → `Invalid` | tip too low / uncled | size tip off `tip_floor` (50–75th pct) |
+| Tip ~1e9× too small | tip_floor is SOL, not lamports | `× LAMPORTS_PER_SOL` |
+| "failed to deserialize" | base64 without `{encoding:"base64"}` | pass the encoding object |
+| Status poll never lands | result read as a bare array | result is `{ context, value: [...] }` — read `.value` |
+| Status fields `undefined` | wrong field name | response is snake_case (`confirmation_status`, `bundle_id`, `landed_slot`) |
+| HTTP 429 | >1 req/sec/region | back off ≥1s / use regions |
+| `simulateBundle` not found | it's an RPC-node method | call a Jito-Solana RPC, not the block engine |
+
+Full guide: `docs/troubleshooting.md`.
+
+## Resources
+
+- `resources/block-engine-reference.md` — endpoints, methods, params/responses, limits.
+- `resources/tip-accounts.md` — tip accounts, tip-floor sizing, the SOL/lamports trap.
+- `docs/troubleshooting.md` — symptom-first failure modes.
+- `templates/send-jito-bundle.ts` — reusable bundle sender.
+- Official docs: <https://docs.jito.wtf/lowlatencytxnsend/>
+
+## Skill Structure
+
+```
+jito-bundles/
+├── SKILL.md
+├── docs/
+│   └── troubleshooting.md
+├── examples/
+│   ├── _shared/util.ts
+│   ├── send-bundle/example.ts
+│   └── tip-floor-and-confirm/example.ts
+├── resources/
+│   ├── block-engine-reference.md
+│   └── tip-accounts.md
+└── templates/
+    └── send-jito-bundle.ts
+```

--- a/skills/jito-bundles/docs/troubleshooting.md
+++ b/skills/jito-bundles/docs/troubleshooting.md
@@ -1,0 +1,69 @@
+# Jito bundles — troubleshooting
+
+Symptom-first guide to the failure modes that actually bite. Most "my bundle
+didn't land" reports are one of the first three.
+
+## Bundle "succeeds" but nothing lands on-chain
+`sendBundle` returning a `bundle_id` means **received, not landed**. You must
+poll `getInflightBundleStatuses` (and then `getBundleStatuses`). If you treat the
+`bundle_id` as success, you'll silently miss every drop.
+- **Fix:** poll to a terminal state (`Landed` / `Failed` / `Invalid`).
+
+## Bundle stays `Pending` then goes `Invalid`
+The 5-minute lookback expired without landing — almost always **tip too low** so
+it lost the auction, or it was **uncled** (leader skipped).
+- **Fix:** size the tip off the tip-floor feed (50th–75th percentile), not the
+  1,000-lamport minimum. See `resources/tip-accounts.md`.
+
+## Tip is way too small (off by ~1e9)
+The `tip_floor` percentiles are in **SOL**, not lamports.
+- **Fix:** `Math.ceil(solValue * LAMPORTS_PER_SOL)`. Forgetting `*1e9` underpays
+  by a billion-fold and the bundle never wins.
+
+## Server rejects the transactions / "failed to deserialize"
+You sent base64 strings without telling Jito.
+- **Fix:** `sendBundle` params second element **must** be `{ "encoding": "base64" }`.
+  The legacy default is base58, so omitting it mis-decodes base64 payloads.
+
+## Status poll never lands (even when the bundle landed)
+You read the status result as a bare array. Both `getInflightBundleStatuses` and
+`getBundleStatuses` wrap their result as `{ context, value: [...] }`.
+- **Fix:** unwrap `.value` — e.g. `result.value?.[0]?.status`. Indexing the
+  wrapper object with `[0]` yields `undefined`, so the poll never sees a terminal
+  state and times out.
+
+## Status fields come back `undefined`
+You camelCased a field name.
+- **Fix:** the status responses are **snake_case** — `confirmation_status`,
+  `bundle_id`, `landed_slot`, `transactions`, `slot`, `err`.
+
+## HTTP 429
+You exceeded the default **1 request/sec per IP per region**. Aggressive status
+polling is the usual culprit.
+- **Fix:** sleep ≥ 1s between calls, batch up to 5 bundle IDs per status call, or
+  spread requests across regional hosts (limits are per-region).
+
+## Bundle `Failed` immediately
+A transaction in the bundle errored or used a **stale blockhash**. Bundles are
+atomic — one bad tx rejects all of them.
+- **Fix:** build and sign as late as possible (blockhashes expire in ~60–90s);
+  simulate each tx (`simulateTransaction`) or the whole bundle (`simulateBundle`
+  on a Jito-Solana RPC) before sending; ensure every tx shares one recent blockhash.
+
+## Calling `simulateBundle` returns "method not found"
+`simulateBundle` is **not** a Block Engine method — it lives on a **Jito-Solana
+RPC node**.
+- **Fix:** point it at a Jito-Solana RPC endpoint, not `mainnet.block-engine.jito.wtf`.
+
+## Bundle ID never appears in `sendTransaction` response body
+For the single-tx `sendTransaction?bundleOnly=true` path, the `bundle_id` is in
+the **`x-bundle-id`** response header — not the JSON body, and not `x-bundle-auth`.
+
+## Low landing rate under load
+Always tipping the same account causes write-lock contention.
+- **Fix:** fetch `getTipAccounts` and pick one of the 8 **at random** per bundle.
+
+## `params` shape errors
+Status methods nest one level deeper than people expect:
+`params: [[ "id1", "id2" ]]`, not `params: [ "id1", "id2" ]`. The same
+double-array applies to `sendBundle`'s transaction list.

--- a/skills/jito-bundles/examples/_shared/util.ts
+++ b/skills/jito-bundles/examples/_shared/util.ts
@@ -1,0 +1,193 @@
+/**
+ * Shared helpers for the jito-bundles examples.
+ *
+ * Pure @solana/web3.js v1.x — no Jito SDK dependency. Talking to the Jito Block
+ * Engine is plain JSON-RPC over HTTPS, so a small `fetch` wrapper is all you need.
+ *
+ * Every fact encoded here (endpoint paths, encoding rules, response field casing,
+ * tip-floor units) is verified against https://docs.jito.wtf/lowlatencytxnsend/.
+ */
+
+import {
+  Connection,
+  Keypair,
+  LAMPORTS_PER_SOL,
+  PublicKey,
+  SystemProgram,
+  TransactionInstruction,
+  TransactionMessage,
+  VersionedTransaction,
+} from "@solana/web3.js";
+
+// --- Connection / signer -----------------------------------------------------
+
+/** A normal Solana RPC connection. Jito does NOT provide blockhashes — use your own RPC. */
+export function getConnection(rpcUrl = "https://api.mainnet-beta.solana.com"): Connection {
+  return new Connection(rpcUrl, "confirmed");
+}
+
+/** Load a keypair from a JSON secret-key array in an env var (e.g. PAYER_SECRET_KEY). */
+export function loadKeypair(envVar = "PAYER_SECRET_KEY"): Keypair {
+  const raw = process.env[envVar];
+  if (!raw) throw new Error(`Missing ${envVar} (JSON array of the 64-byte secret key)`);
+  return Keypair.fromSecretKey(Uint8Array.from(JSON.parse(raw)));
+}
+
+// --- Jito Block Engine JSON-RPC ----------------------------------------------
+
+/**
+ * Block Engine base URL. Regional hosts (lower latency) follow the pattern
+ * https://<region>.mainnet.block-engine.jito.wtf — e.g. amsterdam, dublin,
+ * frankfurt, london, ny, slc, singapore, tokyo. The rate limit is per-region,
+ * so different regions have independent quotas.
+ */
+export const BLOCK_ENGINE = "https://mainnet.block-engine.jito.wtf";
+
+/**
+ * One quirk to internalize: the request PATH is not uniform.
+ *   - sendBundle      -> /api/v1/bundles
+ *   - sendTransaction -> /api/v1/transactions
+ *   - everything else -> /api/v1/<methodName>   (method name IS the path)
+ */
+function pathForMethod(method: string): string {
+  if (method === "sendBundle") return "/api/v1/bundles";
+  if (method === "sendTransaction") return "/api/v1/transactions";
+  return `/api/v1/${method}`;
+}
+
+/** Minimal JSON-RPC POST to the Block Engine. Throws on a JSON-RPC `error`. */
+export async function jitoRpc<T = unknown>(
+  method: string,
+  params: unknown[],
+  baseUrl = BLOCK_ENGINE,
+): Promise<T> {
+  const res = await fetch(`${baseUrl}${pathForMethod(method)}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+  });
+  // Default rate limit is 1 request/sec per IP per region; excess returns HTTP 429.
+  if (res.status === 429) throw new Error("Jito rate limit (429) — back off >= 1s or use another region");
+  const json = (await res.json()) as { result?: T; error?: unknown };
+  if (json.error) throw new Error(`Jito RPC ${method} error: ${JSON.stringify(json.error)}`);
+  return json.result as T;
+}
+
+/** Fetch the 8 tip accounts at runtime. Do NOT hardcode — Jito may rotate them. */
+export async function getTipAccounts(baseUrl = BLOCK_ENGINE): Promise<PublicKey[]> {
+  const accounts = await jitoRpc<string[]>("getTipAccounts", [], baseUrl);
+  return accounts.map((a) => new PublicKey(a));
+}
+
+/** Pick one tip account at random — spreads write-lock contention across the 8. */
+export function pickTipAccount(accounts: PublicKey[]): PublicKey {
+  return accounts[Math.floor(Math.random() * accounts.length)];
+}
+
+/**
+ * Derive a competitive tip (in LAMPORTS) from the public tip-floor feed.
+ *
+ * CRITICAL: tip_floor percentiles are expressed in SOL (decimal floats), NOT
+ * lamports. You MUST multiply by LAMPORTS_PER_SOL. Feeding the raw float into
+ * SystemProgram.transfer would underpay by 1e9x and the bundle would never land.
+ *
+ * The 1000-lamport minimum is only an acceptance floor; under contention you
+ * generally need the ema50/75th-percentile amount to actually win the auction.
+ */
+export async function fetchTipLamports(
+  percentile: "ema_landed_tips_50th_percentile" | "landed_tips_75th_percentile" = "ema_landed_tips_50th_percentile",
+): Promise<number> {
+  const res = await fetch("https://bundles.jito.wtf/api/v1/bundles/tip_floor");
+  const [floor] = (await res.json()) as Array<Record<string, number | string>>;
+  const sol = Number(floor?.[percentile] ?? 0); // feed may serialize percentiles as strings
+  return Math.max(Math.ceil(sol * LAMPORTS_PER_SOL), 1000); // SOL -> lamports, floor 1000
+}
+
+/** Build a SOL-transfer tip instruction to a tip account. `from` must sign the tx it lands in. */
+export function tipInstruction(from: PublicKey, tipAccount: PublicKey, lamports: number): TransactionInstruction {
+  return SystemProgram.transfer({ fromPubkey: from, toPubkey: tipAccount, lamports });
+}
+
+/** Serialize a fully-signed VersionedTransaction to the base64 string sendBundle expects. */
+export function encodeBase64(tx: VersionedTransaction): string {
+  return Buffer.from(tx.serialize()).toString("base64");
+}
+
+/** Compile + sign a v0 transaction from instructions sharing one blockhash. */
+export function buildV0Tx(
+  payer: PublicKey,
+  blockhash: string,
+  instructions: TransactionInstruction[],
+  signers: Keypair[],
+): VersionedTransaction {
+  const msg = new TransactionMessage({ payerKey: payer, recentBlockhash: blockhash, instructions }).compileToV0Message();
+  const tx = new VersionedTransaction(msg);
+  tx.sign(signers);
+  return tx;
+}
+
+// --- Bundle status types + polling ------------------------------------------
+
+/**
+ * getInflightBundleStatuses value object. snake_case fields.
+ *
+ * Like getBundleStatuses, the RPC result is wrapped as
+ * `{ context: { slot }, value: [InflightStatus] }` — unwrap `.value`.
+ */
+export interface InflightStatus {
+  bundle_id: string;
+  status: "Invalid" | "Pending" | "Failed" | "Landed";
+  landed_slot: number | null;
+}
+
+/** JSON-RPC results for the status methods are wrapped in this envelope. */
+export interface RpcContextValue<T> {
+  context: { slot: number };
+  value: T[];
+}
+
+/**
+ * getBundleStatuses value object.
+ *
+ * The RPC result is wrapped as `{ context: { slot }, value: [BundleStatus | null] }`
+ * — always unwrap `.value`. Every field here is snake_case (bundle_id,
+ * transactions, slot, confirmation_status, err).
+ */
+export interface BundleStatus {
+  bundle_id: string;
+  transactions: string[]; // landed on-chain signatures (base58)
+  slot: number;
+  confirmation_status: "processed" | "confirmed" | "finalized";
+  err: unknown; // { Ok: null } on success, Solana TransactionError otherwise
+}
+
+/**
+ * Poll a bundle to a terminal state. Fast path is getInflightBundleStatuses
+ * (5-minute lookback); once Landed we fetch getBundleStatuses for the real
+ * signatures + commitment.
+ *
+ * Returns the landed BundleStatus, or throws on Failed/Invalid/timeout.
+ */
+export async function waitForBundle(
+  bundleId: string,
+  { timeoutMs = 30_000, pollMs = 1_500, baseUrl = BLOCK_ENGINE }: { timeoutMs?: number; pollMs?: number; baseUrl?: string } = {},
+): Promise<BundleStatus> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    // params nest one level deeper than you'd expect: [[id1, id2, ...]] (max 5 ids).
+    // The result is wrapped { context, value: [...] } — unwrap `.value` (the same
+    // envelope getBundleStatuses uses).
+    const inflight = await jitoRpc<RpcContextValue<InflightStatus> | null>("getInflightBundleStatuses", [[bundleId]], baseUrl);
+    const status = inflight?.value?.[0]?.status;
+    if (status === "Landed") {
+      const statuses = await jitoRpc<RpcContextValue<BundleStatus | null>>("getBundleStatuses", [[bundleId]], baseUrl);
+      const landed = statuses.value?.[0];
+      if (landed) return landed;
+    }
+    if (status === "Failed" || status === "Invalid") {
+      throw new Error(`Bundle ${bundleId} ended as ${status}`);
+    }
+    await new Promise((r) => setTimeout(r, pollMs)); // respect 1 req/s/region
+  }
+  throw new Error(`Bundle ${bundleId} did not land within ${timeoutMs}ms`);
+}

--- a/skills/jito-bundles/examples/send-bundle/example.ts
+++ b/skills/jito-bundles/examples/send-bundle/example.ts
@@ -1,0 +1,78 @@
+/**
+ * Send a Jito bundle of two transactions, atomically, and confirm it landed.
+ *
+ * Demonstrates the whole canonical flow with raw JSON-RPC (no Jito SDK):
+ *   getTipAccounts -> build v0 txs (tip in the last) -> base64 sendBundle -> poll.
+ *
+ * The two transfers either BOTH land in the same slot, or NEITHER does — that
+ * all-or-nothing property is the reason to use a bundle instead of two sends.
+ *
+ * Run (mainnet — costs real SOL + tip):
+ *   PAYER_SECRET_KEY='[..64 ints..]' RPC_URL='https://your-rpc' ts-node example.ts
+ */
+
+import { PublicKey, SystemProgram } from "@solana/web3.js";
+import {
+  buildV0Tx,
+  encodeBase64,
+  fetchTipLamports,
+  getConnection,
+  getTipAccounts,
+  jitoRpc,
+  loadKeypair,
+  pickTipAccount,
+  tipInstruction,
+  waitForBundle,
+} from "../_shared/util";
+
+async function main() {
+  const connection = getConnection(process.env.RPC_URL);
+  const payer = loadKeypair("PAYER_SECRET_KEY");
+
+  // Two unrelated recipients — stand-ins for "two things that must happen together".
+  const recipientA = new PublicKey("11111111111111111111111111111112");
+  const recipientB = new PublicKey("11111111111111111111111111111113");
+
+  // 1. A random tip account (of the 8) and a competitive, tip-floor-derived tip.
+  const tipAccounts = await getTipAccounts();
+  const tipAccount = pickTipAccount(tipAccounts);
+  const tipLamports = await fetchTipLamports(); // already SOL->lamports, floored at 1000
+
+  // 2. One blockhash shared by every tx in the bundle (single-slot execution).
+  const { blockhash } = await connection.getLatestBlockhash("confirmed");
+
+  // tx #1: first transfer (no tip)
+  const tx1 = buildV0Tx(
+    payer.publicKey,
+    blockhash,
+    [SystemProgram.transfer({ fromPubkey: payer.publicKey, toPubkey: recipientA, lamports: 100_000 })],
+    [payer],
+  );
+
+  // tx #2 (LAST): second transfer + the tip, so a failed bundle never pays the tip.
+  const tx2 = buildV0Tx(
+    payer.publicKey,
+    blockhash,
+    [
+      SystemProgram.transfer({ fromPubkey: payer.publicKey, toPubkey: recipientB, lamports: 100_000 }),
+      tipInstruction(payer.publicKey, tipAccount, tipLamports),
+    ],
+    [payer],
+  );
+
+  // 3. Encode base64 and send. {encoding:'base64'} is REQUIRED (legacy default is base58).
+  const encoded = [tx1, tx2].map(encodeBase64);
+  const bundleId = await jitoRpc<string>("sendBundle", [encoded, { encoding: "base64" }]);
+  console.log(`Bundle received (NOT yet landed): ${bundleId}`);
+  console.log(`Tipped ${tipLamports} lamports to ${tipAccount.toBase58()}`);
+
+  // 4. bundle_id only means "received" — poll until it actually lands.
+  const status = await waitForBundle(bundleId);
+  console.log(`Landed in slot ${status.slot} (${status.confirmation_status})`);
+  status.transactions.forEach((sig, i) => console.log(`  tx${i + 1}: https://solscan.io/tx/${sig}`));
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/skills/jito-bundles/examples/tip-floor-and-confirm/example.ts
+++ b/skills/jito-bundles/examples/tip-floor-and-confirm/example.ts
@@ -1,0 +1,50 @@
+/**
+ * Size the tip from the live tip-floor feed, send via the reusable template,
+ * and confirm to finality.
+ *
+ * The headline gotcha this guards against: the tip_floor percentiles are in
+ * SOL, not lamports. `fetchTipLamports` does the SOL->lamports conversion for
+ * you; doing it by hand and forgetting the *1e9 is the #1 reason a bundle
+ * silently never lands.
+ *
+ * Run (mainnet — costs real SOL + tip):
+ *   PAYER_SECRET_KEY='[..64 ints..]' RPC_URL='https://your-rpc' ts-node example.ts
+ */
+
+import { LAMPORTS_PER_SOL, PublicKey, SystemProgram } from "@solana/web3.js";
+import { fetchTipLamports, getConnection, loadKeypair } from "../_shared/util";
+import { assertBundleOk, sendJitoBundle } from "../../templates/send-jito-bundle";
+
+async function main() {
+  const connection = getConnection(process.env.RPC_URL);
+  const payer = loadKeypair("PAYER_SECRET_KEY");
+  const recipient = new PublicKey("11111111111111111111111111111112");
+
+  // Pay the 75th percentile when you actually care about landing under contention.
+  // (ema_landed_tips_50th_percentile is the cheaper baseline.)
+  const tipLamports = await fetchTipLamports("landed_tips_75th_percentile");
+  console.log(`tip-floor 75th pct => ${tipLamports} lamports (${tipLamports / LAMPORTS_PER_SOL} SOL)`);
+
+  // A single real transaction; the template appends the tip into this last (only) tx.
+  const result = await sendJitoBundle(connection, {
+    payer,
+    tipLamports,
+    groups: [
+      {
+        instructions: [
+          SystemProgram.transfer({ fromPubkey: payer.publicKey, toPubkey: recipient, lamports: 50_000 }),
+        ],
+        signers: [payer],
+      },
+    ],
+  });
+
+  assertBundleOk(result.status); // throws if it landed but the tx errored
+  console.log(`Bundle ${result.bundleId} landed in slot ${result.status.slot} (${result.status.confirmation_status})`);
+  console.log(`Signature: https://solscan.io/tx/${result.signatures[0]}`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/skills/jito-bundles/resources/block-engine-reference.md
+++ b/skills/jito-bundles/resources/block-engine-reference.md
@@ -1,0 +1,79 @@
+# Jito Block Engine — JSON-RPC reference
+
+All facts verified against <https://docs.jito.wtf/lowlatencytxnsend/> (June 2026).
+The Block Engine speaks plain JSON-RPC over HTTPS — no Jito SDK is required.
+
+## Endpoints
+
+Base URL (global): `https://mainnet.block-engine.jito.wtf`
+
+Regional hosts (lower latency, **independent per-region rate limits**) follow
+`https://<region>.mainnet.block-engine.jito.wtf`:
+
+`amsterdam` · `dublin` · `frankfurt` · `london` · `ny` · `slc` · `singapore` · `tokyo`
+
+Testnet: `https://testnet.block-engine.jito.wtf`
+
+> The region roster changes over time — don't hardcode beyond the global host
+> without re-checking the docs.
+
+## Path mapping (NOT uniform)
+
+| Method | HTTP path |
+|--------|-----------|
+| `sendBundle` | `/api/v1/bundles` |
+| `sendTransaction` | `/api/v1/transactions` |
+| `getBundleStatuses` | `/api/v1/getBundleStatuses` |
+| `getInflightBundleStatuses` | `/api/v1/getInflightBundleStatuses` |
+| `getTipAccounts` | `/api/v1/getTipAccounts` |
+
+`Content-Type: application/json`. JSON-RPC envelope: `{ "jsonrpc":"2.0", "id":1, "method":..., "params":... }`.
+
+## Methods
+
+### `sendBundle`
+- **params:** `[ [tx1, tx2, … up to 5], { "encoding": "base64" } ]`
+- Transactions are **fully-signed**, encoded as **base64 (recommended)** or base58 (slow, **DEPRECATED**).
+- ⚠️ The `encoding` default is **base58**. When you send base64 strings you **must** pass `{ "encoding": "base64" }` explicitly, or they are mis-decoded.
+- **result:** `bundle_id` (string) = SHA-256 of the bundle's transaction signatures.
+- A result means **received, not landed.** You must poll status.
+- A **tip** (SOL transfer to a tip account) must be present in one of the txns.
+
+### `getInflightBundleStatuses` (fast, 5-minute lookback)
+- **params:** `[ [bundleId, … up to 5] ]`  ← note the double-array nesting
+- **result:** `{ context: { slot }, value: [ { bundle_id, status, landed_slot } ] }` — unwrap `.value` (same envelope as `getBundleStatuses`).
+- `status`: `Invalid` (not in system / 5-min window expired) · `Pending` · `Failed` (all regions failed it) · `Landed`
+- `landed_slot`: `u64 | null`
+
+### `getBundleStatuses` (on-chain confirmation)
+- **params:** `[ [bundleId, … up to 5] ]`
+- **result:** `{ context: { slot }, value: [ { bundle_id, transactions, slot, confirmation_status, err } | null ] }`
+- Fields are **snake_case**: `bundle_id`, `transactions`, `slot`, `confirmation_status`, `err`.
+- `transactions`: array of base58 signatures — the actual landed, on-chain tx signatures.
+- `confirmation_status`: `processed | confirmed | finalized`
+- `err`: `{ "Ok": null }` on success, else a Solana `TransactionError`.
+- A not-found / not-landed bundle's `value` entry is `null`.
+
+### `getTipAccounts`
+- **params:** `[]`
+- **result:** array of 8 tip-account pubkey strings. Fetch at runtime; don't hardcode.
+
+### `sendTransaction` (single-tx MEV-protected path — different from bundles)
+- **params:** `[ encodedSignedTx, { "encoding": "base64" } ]`; proxy to Solana `sendTransaction`, always `skip_preflight=true`.
+- Query `?bundleOnly=true` enables revert protection (sent as a 1-tx bundle).
+- When sent as a bundle, the `bundle_id` comes back in the **`x-bundle-id`** response header (not the JSON body, not `x-bundle-auth`).
+- Fee guidance for this path is a **70/30 priority-fee/tip split** — *unlike* `sendBundle`, where only the tip matters.
+
+## Limits & auth
+- **Rate limit:** 1 request/sec **per IP per region** (HTTP `429` on excess). Per-region, so spreading across regional hosts multiplies throughput.
+- **Auth:** no approved key needed for default sends. Higher limits use an optional UUID via the `x-jito-auth: <uuid>` header or `?uuid=<uuid>` query.
+- **Bundle size:** max **5 transactions**; max **5 bundle IDs** per status call.
+
+## `simulateBundle`
+Not a Block Engine method — it's a **Jito-Solana RPC node** method (alongside
+`simulateTransaction`). Point it at a Jito-Solana RPC, not `mainnet.block-engine.jito.wtf`.
+
+## SDKs (optional)
+- `jito-js-rpc` — maintained JSON-RPC TS SDK.
+- `jito-ts` — heavier gRPC SearcherClient (optional). Not needed for HTTP bundle sending.
+- For `@solana/web3.js` v1.x users, raw `fetch` needs **no Jito dependency** at all.

--- a/skills/jito-bundles/resources/tip-accounts.md
+++ b/skills/jito-bundles/resources/tip-accounts.md
@@ -1,0 +1,67 @@
+# Jito tips — accounts, sizing & economics
+
+Verified against <https://docs.jito.wtf/lowlatencytxnsend/> and the live
+tip-floor feed (June 2026).
+
+## What the tip is
+A **tip is mandatory** for a bundle to be considered by the auction. It is just a
+**SOL transfer to one of 8 Jito tip accounts**, included as an instruction
+(top-level or CPI) inside one of the bundle's transactions.
+
+- The transfer **source (`fromPubkey`) must sign** the transaction it lands in.
+- **For `sendBundle`, only the tip wins the auction** — the Solana priority fee
+  does *not* factor into bundle selection. (You may still add ComputeBudget
+  priority-fee instructions for on-chain CU pricing, but they don't help you
+  *land the bundle*.)
+
+## The 8 tip accounts
+Fetch them at runtime with `getTipAccounts` and **pick one at random per bundle**
+to spread write-lock contention. Treat the list below as a cache/fallback only —
+Jito may rotate it.
+
+```
+96gYZGLnJYVFmbjzopPSU6QiEV5fGqZNyN9nmNhvrZU5
+HFqU5x63VTqvQss8hp11i4wVV8bD44PvwucfZ2bU7gRe
+Cw8CFyM9FkoMi7K7Crf6HNQqf4uEMzpKw6QNghXLvLkY
+ADaUMid9yfUytqMBgopwjb2DTLSokTSzL1zt6iGPaS49
+DfXygSm4jCyNCybVYYK6DwvWqjKee8pbDmJGcLWNDXjh
+ADuUkR4vqLUMWXxW9gh6D6L8pMSawimctcNZ5pGwDcEt
+DttWaMuVvTiduZRnguLF7jNxTgiMBZ1hyAumKUiL2KRL
+3AVi9Tg9Uo68tJfuvoKvqKNWKkC5wPdSSdeBnizKZ6jT
+```
+
+## Sizing the tip
+
+- **Minimum:** 1,000 lamports. This is an *acceptance floor*, not a landing
+  guarantee — under contention it is usually too low to win.
+- **Tip-floor feed (recommended):**
+  - REST: `GET https://bundles.jito.wtf/api/v1/bundles/tip_floor`
+  - WebSocket: `wss://bundles.jito.wtf/api/v1/bundles/tip_stream`
+  - Returns one object with: `landed_tips_25th_percentile`,
+    `landed_tips_50th_percentile`, `landed_tips_75th_percentile`,
+    `landed_tips_95th_percentile`, `landed_tips_99th_percentile`,
+    `ema_landed_tips_50th_percentile`.
+
+### ⚠️ The unit trap (most common correctness bug)
+The tip-floor percentiles are expressed in **SOL** (decimal floats), **not
+lamports**. You **must** multiply by `LAMPORTS_PER_SOL` (1e9):
+
+```ts
+const [floor] = await (await fetch("https://bundles.jito.wtf/api/v1/bundles/tip_floor")).json();
+const ema50Sol = floor.ema_landed_tips_50th_percentile;        // e.g. 0.0000099 SOL
+const tipLamports = Math.max(Math.ceil(ema50Sol * 1e9), 1000); // <-- *1e9, then floor at 1000
+```
+
+Feeding the raw float (`0.0000099`) into `SystemProgram.transfer`'s `lamports`
+underpays by ~1e9× and the bundle never lands.
+
+**Rule of thumb:** `ema_landed_tips_50th_percentile` is a cheap baseline;
+use the 75th/95th percentile when you genuinely need to compete.
+
+## Placement
+Put the tip in the **last transaction** of the bundle, ideally folded into the
+**same tx that runs your real logic**. Because bundles are atomic, if your work
+fails the whole bundle is rejected and the tip is never paid — placement doesn't
+change that, but a standalone tip-only tx increases "uncle bandit" exposure, so
+prefer embedding it. The 5-transaction cap **includes** a dedicated tip tx if you
+use one, so folding the tip into a real tx also saves a slot.

--- a/skills/jito-bundles/templates/send-jito-bundle.ts
+++ b/skills/jito-bundles/templates/send-jito-bundle.ts
@@ -1,0 +1,110 @@
+/**
+ * Reusable Jito bundle sender for @solana/web3.js v1.x.
+ *
+ * Drop this in, pass it your instruction groups + signers, and it will:
+ *   1. fetch tip accounts + a competitive tip from the tip-floor feed
+ *   2. inject the tip transfer into the LAST transaction (so a failed strategy
+ *      doesn't pay the tip — bundles are atomic, all-or-nothing)
+ *   3. compile every group into a v0 VersionedTransaction sharing one blockhash
+ *   4. base64-encode and POST sendBundle (with the REQUIRED {encoding:'base64'})
+ *   5. poll to a terminal state and return the landed signatures
+ *
+ * No Jito npm dependency — the Block Engine is plain JSON-RPC over HTTPS.
+ */
+
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  TransactionInstruction,
+  VersionedTransaction,
+} from "@solana/web3.js";
+import {
+  BLOCK_ENGINE,
+  BundleStatus,
+  buildV0Tx,
+  encodeBase64,
+  fetchTipLamports,
+  getTipAccounts,
+  jitoRpc,
+  pickTipAccount,
+  tipInstruction,
+  waitForBundle,
+} from "../examples/_shared/util";
+
+export interface TxGroup {
+  /** Instructions for one transaction in the bundle. */
+  instructions: TransactionInstruction[];
+  /** Additional signers for this transaction. The bundle's `payer` is added automatically. */
+  signers: Keypair[];
+}
+
+export interface SendBundleOptions {
+  /** Fee payer + tipper. Added automatically as a signer of EVERY transaction (it is the fee payer for all of them). */
+  payer: Keypair;
+  /** 1..5 transaction groups, executed in order, atomically. */
+  groups: TxGroup[];
+  /** Explicit tip in lamports. If omitted, derived from the tip-floor feed. */
+  tipLamports?: number;
+  /** Block Engine base URL (use a regional host for lower latency). */
+  baseUrl?: string;
+  /** Confirmation timeout. */
+  timeoutMs?: number;
+}
+
+export interface SendBundleResult {
+  bundleId: string;
+  status: BundleStatus;
+  /** Landed on-chain transaction signatures, in bundle order. */
+  signatures: string[];
+}
+
+export async function sendJitoBundle(connection: Connection, opts: SendBundleOptions): Promise<SendBundleResult> {
+  const { payer, groups, baseUrl = BLOCK_ENGINE, timeoutMs = 30_000 } = opts;
+
+  if (groups.length < 1 || groups.length > 5) {
+    throw new Error(`A bundle must contain 1..5 transactions (got ${groups.length})`);
+  }
+
+  // 1. Tip account (random of 8) + tip amount (tip-floor-derived unless given).
+  const tipAccounts = await getTipAccounts(baseUrl);
+  const tipAccount = pickTipAccount(tipAccounts);
+  const tipLamports = opts.tipLamports ?? (await fetchTipLamports());
+
+  // 2. Inject the tip into the LAST group, paid by `payer`.
+  const lastIndex = groups.length - 1;
+  const groupsWithTip = groups.map((g, i) =>
+    i === lastIndex
+      ? { ...g, instructions: [...g.instructions, tipInstruction(payer.publicKey, tipAccount, tipLamports)] }
+      : g,
+  );
+
+  // 3. One blockhash for every tx in the bundle (they all execute in one slot).
+  //    `payer` is the fee payer of every tx, so it must sign every tx — add it
+  //    automatically (deduped) so a caller can't accidentally produce an unsigned tx.
+  const { blockhash } = await connection.getLatestBlockhash("confirmed");
+  const txs: VersionedTransaction[] = groupsWithTip.map((g) => {
+    const signers = g.signers.some((s) => s.publicKey.equals(payer.publicKey)) ? g.signers : [payer, ...g.signers];
+    return buildV0Tx(payer.publicKey, blockhash, g.instructions, signers);
+  });
+
+  // 4. Encode base64 and send. The {encoding:'base64'} object is REQUIRED:
+  //    the legacy default is base58, which would mis-decode these payloads.
+  const encoded = txs.map(encodeBase64);
+  const bundleId = await jitoRpc<string>("sendBundle", [encoded, { encoding: "base64" }], baseUrl);
+
+  // 5. A bundle_id means RECEIVED, not LANDED — poll to a terminal state.
+  const status = await waitForBundle(bundleId, { timeoutMs, baseUrl });
+  return { bundleId, status, signatures: status.transactions };
+}
+
+/** Convenience: assert no transaction in the landed bundle errored. */
+export function assertBundleOk(status: BundleStatus): void {
+  const ok = status.err === null || (typeof status.err === "object" && (status.err as { Ok?: null }).Ok === null);
+  if (!ok) throw new Error(`Bundle landed but a transaction errored: ${JSON.stringify(status.err)}`);
+}
+
+/** Build a tip-only transaction (use only when you can't fold the tip into a real tx). */
+export function buildTipOnlyTx(payer: Keypair, blockhash: string, tipAccount: PublicKey, lamports: number): VersionedTransaction {
+  return buildV0Tx(payer.publicKey, blockhash, [tipInstruction(payer.publicKey, tipAccount, lamports)], [payer]);
+}


### PR DESCRIPTION
## Summary

Adds a `jito-bundles` skill: landing atomic, all-or-nothing transaction bundles on Solana via the Jito Block Engine with `@solana/web3.js` v1.x (raw JSON-RPC — no Jito SDK dependency).

The skill covers the full flow an agent needs:
- fetch tip accounts at runtime (`getTipAccounts`) and pick one at random
- size the tip from the `tip_floor` feed, with the **SOL → lamports** conversion that's the most common underpay bug
- build v0 `VersionedTransaction`s sharing one blockhash
- send base64-encoded bundles (explicit `{encoding:"base64"}` to avoid the deprecated base58 default)
- poll `getInflightBundleStatuses` → `getBundleStatuses` to confirmation, unwrapping the `{context,value}` envelope and reading the snake_case fields

## Contents
`SKILL.md`, two runnable examples (`send-bundle`, `tip-floor-and-confirm`), a reusable `send-jito-bundle.ts` template, `resources/` (block-engine + tip-account references), and `docs/troubleshooting.md`. Registered in `marketplace.json` (additive, category *Client Development*).

## Notes
- All Jito API facts (endpoint paths, the `{context,value}` status wrapper, snake_case response fields like `confirmation_status`, tip rules, encoding) verified against docs.jito.wtf.
- `scripts/validate-marketplace.js` passes.