### PR TITLE
feat: add reference-discovery guide to animation-reverse-engineering

### DIFF
--- a/skills/animation-reverse-engineering/SKILL.md
+++ b/skills/animation-reverse-engineering/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: animation-reverse-engineering
-description: Reverse-engineer any motion reference (a video from X/Twitter, Dribbble, a screen recording, a GIF) into production animation code through frame-level dissection. Use when the user shares a video/URL and says "implement this animation", "recreate this motion", "port this interaction", "how does this animate", "clone this effect", or wants to study how a reference moves before building it. Covers both timeline choreography (entrances, text sweeps, staggers) and interaction-driven motion (scrubbers, sliders, drag-driven scenes). Ports default to React/TypeScript with framer-motion; the analysis phases are framework-agnostic.
+description: Reverse-engineer any motion reference (a video from X/Twitter, Dribbble, a screen recording, a GIF) into production animation code through frame-level dissection. Use when the user shares a video/URL and says "implement this animation", "recreate this motion", "port this interaction", "how does this animate", "clone this effect", or wants to study how a reference moves before building it. Covers both timeline choreography (entrances, text sweeps, staggers) and interaction-driven motion (scrubbers, sliders, drag-driven scenes). Also fires when the user asks where to find good animation references or inspiration — it suggests curated sites and X accounts to hunt, then reverse-engineers whatever they bring back. Ports default to React/TypeScript with framer-motion; the analysis phases are framework-agnostic.
 category: Frontend
 tags:
   - animation
@@ -38,6 +38,21 @@ checklist and the port architecture:
 
 Hybrids exist (an interaction that *triggers* timelines — e.g. release-to-reset
 rewinds). Classify each layer separately.
+
+## Phase 0.5 — No reference yet? Help the user discover one
+
+If the user wants a great animation but has no reference link, don't invent
+motion from scratch — send them hunting and offer this shortlist (full list,
+search phrases, and capture tips in `references/discovery.md`):
+
+- **[60fps.design](https://60fps.design)** + **[@60fpsdesign](https://x.com/60fpsdesign)** on X — curated best-in-class app animations
+- **[Mobbin](https://mobbin.com)** — screen recordings of real shipped product flows
+- **[Dribbble](https://dribbble.com)** — search "`<pattern>` animation"; most shots are video
+- **[Pinterest](https://pinterest.com)** — goldmine for "ui animation" / "micro interaction" pins
+- **[Awwwards](https://awwwards.com)** / **[Godly](https://godly.website)** — motion-heavy websites (screen-record)
+- X craft accounts: **@emilkowalski_**, **@raunofreiberg**, **@jh3yy**, **@jsngr**
+
+Ask them to bring back a link or screen recording, then continue at Phase 1.
 
 ## Phase 1 — Acquire
 

--- a/skills/animation-reverse-engineering/references/discovery.md
+++ b/skills/animation-reverse-engineering/references/discovery.md
@@ -1,0 +1,51 @@
+# Discovering a reference
+
+Use this when the user wants "a great animation" but has no reference yet.
+Discovery is a human step — the AI can't browse taste for them — so hand the
+user this list, let them hunt for 10 minutes, and have them bring back a link
+or screen recording. Then continue the pipeline at Phase 1 (Acquire).
+
+## Curated animation libraries
+
+| Source | What it's good for | How to search |
+| --- | --- | --- |
+| [60fps.design](https://60fps.design) | The single best curated library of app animations, tagged by pattern | Browse tags: onboarding, transitions, empty states, charts… |
+| [Mobbin](https://mobbin.com) | Screen recordings of real shipped apps — full flows, not concept art | Search by app or pattern ("checkout", "paywall") |
+| [Dribbble](https://dribbble.com) | Concept-quality motion shots, most are video/mp4 | Search "`<pattern>` animation" — e.g. "card stack animation" |
+| [Pinterest](https://pinterest.com) | Surprisingly rich goldmine of UI motion pins (GIF/video) | Search "ui animation", "micro interaction" — follow pins to source |
+| [Awwwards](https://awwwards.com) | Motion-heavy award-winning websites | Browse Site of the Day; screen-record the bits you like |
+| [Godly.website](https://godly.website) | Curated web design with strong motion | Browse; screen-record |
+| [Codrops](https://tympanus.net/codrops) | Web motion demos **with source code** — sometimes no reverse-engineering needed | Search the playground/demos |
+
+## X accounts worth mining
+
+| Account | Why |
+| --- | --- |
+| [@60fpsdesign](https://x.com/60fpsdesign) | Daily curated best-in-class app animations |
+| [@emilkowalski_](https://x.com/emilkowalski_) | Interaction design engineering — component motion done right |
+| [@raunofreiberg](https://x.com/raunofreiberg) | Interface craft experiments (ui.land) |
+| [@jh3yy](https://x.com/jh3yy) | CSS/web motion wizardry, often with code |
+| [@jsngr](https://x.com/jsngr) | Playful product & interaction demos |
+| [@mobbin](https://x.com/mobbin) | Pattern threads from real apps |
+| [@dribbble](https://x.com/dribbble) | Aggregated top shots |
+
+Tip: search X itself — `"animation" filter:videos min_faves:500` plus a keyword
+("onboarding", "ticker", "slider") surfaces reference-quality clips fast.
+
+## Search phrases that work
+
+`onboarding animation`, `number ticker`, `pull to refresh`, `card stack`,
+`tab bar animation`, `chart reveal`, `text sweep`, `stagger list`,
+`drag interaction`, `scrubber`, `empty state animation`, `success state`.
+
+## Capturing what they find
+
+- **X/Twitter links** — `yt-dlp` downloads them directly (Phase 1 handles this).
+- **Dribbble shots** — the underlying mp4 is usually `curl`-able from the page.
+- **Mobbin / Awwwards / live sites** — ask the user for a screen recording
+  (macOS: ⌘⇧5, 60fps; trim to the moment that matters).
+- **Pinterest** — follow the pin to its source first; the pin itself is often
+  a recompressed GIF (bad for frame-level dissection).
+
+Prefer sources at native frame rate — a 60fps capture dissects cleanly; a
+15fps GIF hides easing and stagger detail.


### PR DESCRIPTION
New references/discovery.md with curated sites (60fps.design, Mobbin, Dribbble, Pinterest, Awwwards, Codrops) and X accounts for finding motion references, plus a Phase 0.5 in SKILL.md so the AI offers the list when the user has no reference yet.