### PR TITLE
feat: add solenrich skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -250,6 +250,12 @@
       "category": "Research"
     },
     {
+      "name": "solenrich",
+      "source": "./skills/solenrich",
+      "description": "Solana onchain intelligence pay-per-call over x402: token due diligence verdicts, wallet risk, smart-money and whale flow, memecoin entry/exit signals, cross-venue perps funding, StonkFun reward-coin gems. No API key.",
+      "category": "Data & Analytics"
+    },
+    {
       "name": "squads",
       "source": "./skills/squads",
       "description": "Squads Protocol for multisig wallets, smart accounts, account abstraction, and Grid stablecoin rails",

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ npx skills add sendaifun/skills
 | [birdeye](https://birdeye.so) | Real-time token prices, OHLCV charts, DEX pools, trades, trending tokens, smart money tracking, and wallet analyzer. Fully x402 compatible |
 | [coingecko](skills/coingecko/) | Token prices, DEX pool data, OHLCV charts, trades |
 | [metengine](skills/metengine/) | Smart money analytics for Polymarket, Hyperliquid, and Meteora — wallet scoring, insider detection, capital flow tracking (63 endpoints, x402 pay-per-request) |
+| [solenrich](skills/solenrich/) | Solana onchain intelligence for agents — token due-diligence verdicts, wallet risk, smart-money and whale flow, memecoin entry/exit signals, cross-venue perps funding, StonkFun reward-coin gems (44 endpoints, x402 pay-per-request, no API key) |
 | [wallet-analysis](skills/wallet-analysis/) | Solana-first wallet analysis with Zerion API — portfolio value, token positions, transactions, charts, and wallet PnL |
 
 ### Cross-Chain

--- a/skills/solenrich/SKILL.md
+++ b/skills/solenrich/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: solenrich
+description: SolEnrich onchain intelligence API for Solana agents, pay-per-call over x402 (USDC on Solana or Base) with no API key. Use for wallet risk scoring, token due diligence and rug flags, smart-money and whale tracking, memecoin trenches entry and exit verdicts (runner-scan, trenches-check, exit-signal), cross-venue perps funding and venue comparison (Jupiter, Adrena, Flash, Hyperliquid, dYdX), StonkFun reward-coin gems and payout status, and plain-English questions routed to the right enricher. Returns JSON or an LLM-ready briefing.
+---
+
+# SolEnrich — Solana Onchain Intelligence for Agents
+
+SolEnrich turns raw Solana data into verdicts an agent can act on: SAFE / CAUTION / RISKY for a token,
+EXIT / DERISK / HOLD for a position you hold, GEM / WATCH / NOISE for a StonkFun coin, best venue for a
+perp at your size. 44 paid endpoints plus one free, $0.001 to $0.25 per call, settled over x402. No
+account, no API key: the agent pays USDC per request from its own wallet.
+
+Base URL: `https://api.solenrich.com`
+
+## Overview
+
+Use this skill when the user asks about:
+
+- Is this token safe, is it a rug, who holds it, how much slippage at size
+- Is this wallet risky, is it a bot, what does it hold, how has it performed
+- Where is smart money moving, which proven-winner wallets are buying fresh launches
+- Should I enter, should I exit, is this memecoin still running (the trenches lifecycle)
+- Which perps venue has the best funding or the lowest entry cost for SOL / BTC / ETH
+- Which StonkFun reward coins are paying holders, which look like gems, what to launch against
+- Any plain-English Solana question the agent cannot answer from one source
+
+All scoring is deterministic. There is no LLM in SolEnrich's pipeline; the `llm` format is a template,
+so a briefing costs the same as JSON and never hallucinates.
+
+## Instructions
+
+1. **Discover for free.** `GET /docs` (every endpoint with input schema and scoring methodology),
+   `GET /openapi.json`, `GET /llms.txt`, `GET /.well-known/x402`. Read `resources/endpoints.md` in
+   this skill for the decision table with prices.
+2. **Choose the payment path.**
+   - Agent has a Solana wallet with USDC → x402 from code. Read `resources/x402.md`, then use
+     `examples/x402/pay-per-request.ts`. Base USDC works the same way with the EVM scheme.
+   - Agent has a terminal → `pay curl` from the Solana Foundation `pay` CLI handles the 402 challenge
+     and returns the body. Install: `npm i -g @solana/pay`.
+   - No wallet at all → `POST /demo/enrich` is free (10 calls per hour, one token or wallet) and
+     `stonk-pairs` is free. The MCP endpoint `https://api.solenrich.com/mcp` lists tools but returns
+     payment instructions instead of data.
+3. **Call the endpoint.** Every paid route is `POST /entrypoints/{key}/invoke` with a JSON body. A flat
+   body works (`{ "mint": "...", "format": "llm" }`) and so does an `input` envelope
+   (`{ "input": { ... } }`). `format` is `json` (default), `llm` (briefing), or `both`.
+4. **Pick the endpoint by intent.**
+
+| User intent | Endpoint | Price |
+|---|---|---|
+| Is this token safe / rug check with a verdict | `due-diligence` | $0.02 |
+| Quick token price, liquidity, slippage, risk flags | `enrich-token-light` | $0.002 |
+| Token holders, concentration (HHI), volatility | `enrich-token-full` | $0.004 |
+| Is this wallet risky, is it a bot, what does it hold | `enrich-wallet-light` | $0.002 |
+| Wallet DeFi positions, connected wallets, tx history | `enrich-wallet-full` | $0.005 |
+| Does this wallet trade well (PnL, win rate, Sharpe) | `copy-trade-signals` | $0.01 |
+| Who are the whales and are they buying or selling | `whale-watch` | $0.008 |
+| What are proven winners buying on spot | `smart-money-flow` | $0.10 |
+| Which winners are aping fresh (<6h) launches right now | `smart-money-trenches` | $0.05 |
+| Which fresh tokens are accelerating right now | `runner-scan` | $0.04 |
+| Should I enter THIS token (velocity + smart money + attention) | `trenches-check` | $0.03 |
+| Should I exit the token I hold | `exit-signal` | $0.04 |
+| Best venue for a SOL / BTC / ETH perp at my size | `perps-venue-comparison` | $0.02 |
+| Funding and OI across Jupiter, Adrena, Flash, Hyperliquid, dYdX | `perps-cross-venue-funding` | $0.015 |
+| Where is Hyperliquid smart money positioned | `hyperliquid-smart-money` | $0.05 |
+| Which StonkFun coins look early, real, and paying | `stonk-gems` | $0.03 |
+| Is this StonkFun coin paying holders, what does the tax cost | `stonk-reward-risk` | $0.005 |
+| What to launch on StonkFun and against which quote | `stonk-launch-intel` | $0.02 |
+| A plain-English question, unsure which endpoint | `query` | $0.003 |
+
+   Full table with inputs and the remaining 25 endpoints: `resources/endpoints.md`.
+
+5. **Chain the trade lifecycle in this order.** Find → vet → size → hold → exit:
+   `runner-scan` or `smart-money-trenches` → `trenches-check` on one mint → `due-diligence` →
+   `enrich-token-light` for slippage at size → `exit-signal` while holding. Every response carries a
+   `next_steps` array naming the next call. See `examples/trade-lifecycle.md`.
+6. **Read the transfer tax.** Token-2022 mints (all StonkFun reward coins) carry a `transfer_tax` block
+   on token, runner, trenches-check, and exit-signal responses. `round_trip_pct` is the buy plus sell
+   cost before slippage; `exit-signal.position.net_pnl_after_exit_tax_pct` is the number to act on.
+7. **Present verdicts first, evidence second.** Lead with the verdict word and score, then the two or
+   three reasons the response gives, then the caveats. Never drop the `caveats` array; it says which
+   legs failed or what the data cannot see.
+
+## Examples
+
+### Token safety with a verdict
+
+User: "Is BONK safe to hold?"
+
+```typescript
+import { createPaidFetch } from './examples/x402/pay-per-request';
+const fetch402 = await createPaidFetch();
+const res = await fetch402('https://api.solenrich.com/entrypoints/due-diligence/invoke', {
+  method: 'POST',
+  headers: { 'content-type': 'application/json' },
+  body: JSON.stringify({ mint: 'DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263', format: 'both' }),
+});
+const { verdict, risk_score, risk_factors, llm_summary } = await res.json();
+```
+
+Reply with the verdict, the score, the top risk factors, and the slippage line from the summary.
+
+### Same call from a terminal
+
+```bash
+pay curl -X POST https://api.solenrich.com/entrypoints/due-diligence/invoke \
+  -H 'content-type: application/json' \
+  -d '{"mint":"DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263","format":"llm"}'
+```
+
+### Should I exit
+
+User: "I bought ZCAT at 0.10, should I sell?"
+
+Call `exit-signal` with `{ "mint": "<ZCAT mint>", "entry_price_usd": 0.10 }`. Report `verdict`,
+`exit_score`, `position.unrealized_pnl_pct`, and `position.net_pnl_after_exit_tax_pct` (ZCAT carries a
+300 bps tax, so the net figure is lower). Quote the `reasoning` string.
+
+### Find StonkFun gems
+
+User: "What's worth looking at on StonkFun right now?"
+
+Call `stonk-gems` with `{ "limit": 10, "format": "llm" }`. Show the GEM rows with their reasons and
+warnings, and say that the list refreshes every ten minutes. Follow with `trenches-check` on any GEM the
+user wants to size.
+
+### Plain-English fallback
+
+User: "Should I buy JUP?"
+
+Call `query` with `{ "question": "Should I buy JUP?" }`. It chains due-diligence, token-trend, and
+whale-watch and returns one answer. Use `query` when the intent is compound or unclear; use the specific
+endpoint when it is clear, because it is cheaper and returns typed fields.
+
+## Guidelines
+
+- **DO** start with `-light` endpoints ($0.002) and escalate to `-full` or `due-diligence` only when the
+  light result flags something.
+- **DO** pass `format: "llm"` when the result feeds a context window; it is shorter and reads better.
+- **DO** respect cache windows: results are cached server-side 30 seconds to 10 minutes by data type.
+  Re-polling faster spends money for the same answer. Trenches endpoints unlock liquidity and holder
+  deltas on a second call 5 or more minutes later, not sooner.
+- **DO** use `batch-enrich` for three or more addresses; it amortizes overhead.
+- **DON'T** call `whale-watch` or `enrich-token-full` before `due-diligence`; it already bundles them.
+- **DON'T** treat any verdict as financial advice or auto-execute a trade on it. Confirm with the user
+  before any swap.
+- **DON'T** send the private key anywhere except the local x402 signer. SolEnrich never sees it.
+- Prices are per call in USDC. Read the `pricing` block of any 402 response for the live number.
+
+## Common Errors
+
+### HTTP 402 with a JSON body
+**Cause**: No payment header, or the payment was rejected. The body carries `pricing`, `how_to_pay`,
+and `all_endpoints` (every paid key with its price).
+**Solution**: Use the x402 fetch wrapper or `pay curl`. Confirm the wallet holds USDC and a little SOL
+for fees on Solana, or USDC on Base.
+
+### HTTP 404 on `/entrypoints/<key>/invoke`
+**Cause**: Unknown endpoint key. Keys are lowercase with hyphens, for example `enrich-wallet-light`.
+**Solution**: `GET /entrypoints` lists every key.
+
+### HTTP 400 validation error
+**Cause**: Wrong field name or an address that is not base58 (Solana) or 0x (Hyperliquid endpoints).
+**Solution**: Field names are snake_case (`entry_price_usd`, `max_age_days`). Check the schema in
+`GET /docs` or `GET /openapi.json`.
+
+### `index is warming up` caveat on stonk endpoints
+**Cause**: The server just restarted; the 10-minute StonkFun index rebuilds within a minute.
+**Solution**: Retry after 60 seconds.
+
+### `holders_source: unavailable` or a leg marked FAILED in `caveats`
+**Cause**: An upstream source (RPC, DexScreener, Birdeye) timed out. Verdicts degrade instead of failing.
+**Solution**: Report the caveat with the verdict. Retry later if the missing leg matters.
+
+## References
+
+- Docs (agent-readable JSON): https://api.solenrich.com/docs
+- OpenAPI: https://api.solenrich.com/openapi.json
+- LLM summary of every endpoint: https://api.solenrich.com/llms.txt
+- x402 discovery: https://api.solenrich.com/.well-known/x402
+- MCP (tool listing): https://api.solenrich.com/mcp
+- Landing and pricing: https://solenrich.com
+- x402 protocol: https://www.x402.org/
+- Solana Foundation `pay` CLI: https://github.com/solana-foundation/pay

--- a/skills/solenrich/examples/trade-lifecycle.md
+++ b/skills/solenrich/examples/trade-lifecycle.md
@@ -1,0 +1,46 @@
+# One trade, five calls — the SolEnrich trenches lifecycle
+
+Every SolEnrich response carries a `next_steps` array naming the call that comes next. This is the
+default chain for a memecoin trade, with what to read at each step and what it costs.
+
+| Step | Call | Read | Cost |
+|---|---|---|---|
+| 1. Find | `runner-scan` (velocity) or `smart-money-trenches` (who is buying) or `stonk-gems` (StonkFun) | Ranked candidates with a stage or score and reasons | $0.04 / $0.05 / $0.03 |
+| 2. Vet | `trenches-check` on one mint | `verdict`, `confluence`, `reasoning`, `transfer_tax` | $0.03 |
+| 3. Safety | `due-diligence` | `verdict` SAFE / CAUTION / RISKY, `risk_factors`, concentration | $0.02 |
+| 4. Size | `enrich-token-light` | `slippage_estimates` at $100 / $1K / $10K / $100K, `transfer_tax.round_trip_pct` | $0.002 |
+| 5. Hold | `exit-signal` with `entry_price_usd`, repeated no faster than every 5 minutes | `verdict` EXIT / DERISK / HOLD, `exit_score`, `position.net_pnl_after_exit_tax_pct` | $0.04 per check |
+
+Total to enter with full diligence: about $0.09. Each exit check: $0.04.
+
+## Rules the agent should apply
+
+- **Stop at the first hard flag.** A `RISKY` due-diligence verdict or an `EXIT` from a rug trigger
+  (`lp_pull`, `active_dump`) ends the chain. Report it; do not continue to sizing.
+- **Second look for deltas.** `trenches-check` and `exit-signal` compare against a snapshot from the
+  prior call. Liquidity trend and holder churn are `null` on first sight and fill in on a repeat call
+  5 or more minutes later.
+- **Price the tax.** On Token-2022 mints (every StonkFun reward coin) the `transfer_tax` block gives
+  the buy plus sell cost. A 300 bps coin costs 6% per round trip before slippage; a scalp has to clear
+  that. `exit-signal` already nets the sell leg in `position.net_pnl_after_exit_tax_pct`.
+- **Do not trade on the verdict alone.** Every response ends its `caveats` with "not financial
+  advice". Confirm with the user before any swap.
+
+## Worked example (ZCAT, a StonkFun reward coin on ZEC)
+
+1. `stonk-gems` `{ "limit": 10 }` → ZCAT is not in the list (mcap above the 5M default cap), but
+   `stonk-screener` `{ "live_only": true, "sort": "lastPayout", "limit": 5 }` shows it PAYING 0.1h ago.
+2. `trenches-check` `{ "mint": "HcRLc9VDgjLeK154xDawfb1dmVJ98DoSqcwTHGqiDeJR" }` → MODERATE, with the
+   caveat that the 300 bps tax makes a round trip 6% and weakens an IGNITING read.
+3. `due-diligence` → verdict and holder concentration.
+4. `enrich-token-light` → slippage at the intended size; `risk_flags` includes `transfer_tax`.
+5. Holding from $0.10: `exit-signal` `{ "mint": "...", "entry_price_usd": 0.1 }` → DERISK,
+   `unrealized_pnl_pct` 30.7, `net_pnl_after_exit_tax_pct` 26.8. Report the net figure.
+
+## Perps variant
+
+Find: `perps-cross-venue-funding` `{ "market": "SOL" }` → best entry per side.
+Size: `perps-venue-comparison` `{ "market": "SOL", "side": "long", "size_usd": 5000 }` → cheapest venue at
+that size with warnings.
+Hold: `check-alerts` with the wallet in `wallets[]` and a `since` cursor → `perp_at_risk`,
+`liquidation_approaching`, `pnl_swing`.

--- a/skills/solenrich/examples/x402/pay-per-request.ts
+++ b/skills/solenrich/examples/x402/pay-per-request.ts
@@ -1,0 +1,91 @@
+/**
+ * SolEnrich pay-per-request over x402 (USDC on Solana).
+ *
+ * Builds a `fetch` that answers every HTTP 402 by signing a USDC payment and
+ * retrying. This is the client SolEnrich's own consumer agent (SolScout) uses
+ * in production.
+ *
+ *   npm install @x402/fetch @x402/core @x402/svm @solana/kit @scure/base
+ *
+ * Env:
+ *   SOLANA_PRIVATE_KEY  base58 secret key; wallet needs USDC + ~0.01 SOL for fees
+ *   SOLANA_RPC_URL      optional paid RPC (Helius etc.). Strongly recommended —
+ *                       the public mainnet-beta RPC drops sockets under load.
+ *
+ * Why the schemes are registered by hand: `registerExactSvmScheme` in
+ * @x402/svm accepts an options object but never forwards `rpcUrl`, so it
+ * always falls back to the public RPC. Registering `ExactSvmScheme` and
+ * `ExactSvmSchemeV1` directly keeps the RPC you chose.
+ */
+
+import { createKeyPairSignerFromBytes } from '@solana/kit';
+import { toClientSvmSigner } from '@x402/svm';
+import { x402Client } from '@x402/core/client';
+import { ExactSvmScheme } from '@x402/svm/exact/client';
+import { ExactSvmSchemeV1 } from '@x402/svm/exact/v1/client';
+import { wrapFetchWithPayment } from '@x402/fetch';
+import { base58 } from '@scure/base';
+
+const BASE_URL = 'https://api.solenrich.com';
+
+/** Plain fetch signature — portable across Node, Bun, and Deno typings. */
+export type PaidFetch = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+export async function createPaidFetch(): Promise<PaidFetch> {
+  const secret = process.env.SOLANA_PRIVATE_KEY;
+  if (!secret) throw new Error('SOLANA_PRIVATE_KEY is not set');
+  const rpcUrl = process.env.SOLANA_RPC_URL; // undefined → library default (public RPC)
+
+  const keypair = await createKeyPairSignerFromBytes(base58.decode(secret));
+  const signer = toClientSvmSigner(keypair);
+
+  const client = new x402Client();
+  // v2 scheme, any Solana mainnet CAIP-2 id.
+  client.register('solana:*', new ExactSvmScheme(signer, { rpcUrl }));
+  // v1 scheme for servers that still advertise the older challenge shape.
+  client.registerV1('solana', new ExactSvmSchemeV1(signer, { rpcUrl }));
+
+  return wrapFetchWithPayment(globalThis.fetch, client) as PaidFetch;
+}
+
+/** Call any SolEnrich entrypoint. `input` is the flat parameter object. */
+export async function solenrich<T = unknown>(
+  fetch402: PaidFetch,
+  key: string,
+  input: Record<string, unknown>,
+): Promise<T> {
+  const res = await fetch402(`${BASE_URL}/entrypoints/${key}/invoke`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(input),
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`SolEnrich ${key} → HTTP ${res.status}: ${body.slice(0, 300)}`);
+  }
+  const json = (await res.json()) as { output?: T } & T;
+  // Responses are `{ output: {...} }`; unwrap so callers get the payload.
+  return (json.output ?? json) as T;
+}
+
+// --- Example: the trenches lifecycle on one token -------------------------
+
+if (import.meta.main) {
+  const fetch402 = await createPaidFetch();
+  const BONK = 'DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263';
+
+  const dd = await solenrich<{ verdict: string; risk_score: number; llm_summary?: string }>(
+    fetch402, 'due-diligence', { mint: BONK, format: 'both' },
+  );
+  console.log(`due-diligence: ${dd.verdict} (risk ${dd.risk_score})`);
+
+  const check = await solenrich<{ verdict: string; reasoning: string; transfer_tax: { bps: number } | null }>(
+    fetch402, 'trenches-check', { mint: BONK },
+  );
+  console.log(`trenches-check: ${check.verdict} — ${check.reasoning}`);
+
+  const exit = await solenrich<{ verdict: string; exit_score: number; position: { net_pnl_after_exit_tax_pct: number | null } | null }>(
+    fetch402, 'exit-signal', { mint: BONK, entry_price_usd: 0.00002 },
+  );
+  console.log(`exit-signal: ${exit.verdict} (score ${exit.exit_score}), net after tax ${exit.position?.net_pnl_after_exit_tax_pct}%`);
+}

--- a/skills/solenrich/resources/endpoints.md
+++ b/skills/solenrich/resources/endpoints.md
@@ -1,0 +1,113 @@
+# SolEnrich endpoint reference
+
+All paid endpoints: `POST https://api.solenrich.com/entrypoints/{key}/invoke`, JSON body (flat or wrapped
+in `input`), optional `format: "json" | "llm" | "both"`. Prices in USDC per call, settled over x402 on
+Solana or Base. Live prices: `GET /docs` or the `pricing` block of any 402 response.
+
+Test fixtures used throughout SolEnrich's own tests:
+- Wallet: `vines1vzrYbzLMRdu58ou5XTby4qAqVRLmqo36NKPTg` (Solana Foundation)
+- Token: `DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263` (BONK)
+- StonkFun reward coin: `HcRLc9VDgjLeK154xDawfb1dmVJ98DoSqcwTHGqiDeJR` (ZCAT, quote ZEC, 300 bps)
+
+## Core
+
+| Key | Price | Required input | Returns |
+|---|---|---|---|
+| `enrich-wallet-light` | $0.002 | `address` | SOL balance, holdings, NFT breakdown, labels incl. bot/automation flags, 7-factor risk score |
+| `enrich-wallet-full` | $0.005 | `address` | + DeFi positions, connected wallets, enhanced tx history |
+| `enrich-token-light` | $0.002 | `mint` | Price (median of 3 sources), mcap, volume, liquidity, slippage at $100/$1K/$10K/$100K, risk flags, `transfer_tax` |
+| `enrich-token-full` | $0.004 | `mint` | + top 20 holders, HHI concentration, volatility |
+| `parse-transaction` | $0.001 | `signature` | Type, protocol, transfer breakdown, account roles |
+
+## Risk and composition
+
+| Key | Price | Required input | Returns |
+|---|---|---|---|
+| `due-diligence` | $0.02 | `mint` | Token + whales + holder concentration in one SAFE / CAUTION / RISKY verdict with risk factors |
+| `whale-watch` | $0.008 | `mint` | Top holders with accumulation / distribution flow and supply share |
+| `wallet-graph` | $0.01 | `address` (`depth` 1 or 2) | Connected wallets and suspicious clusters |
+| `copy-trade-signals` | $0.01 | `address` | PnL, win rate, Sharpe, Sortino, max drawdown, profit factor |
+| `batch-enrich` | $0.015 | `addresses[]` (1–25), `type` | Parallel wallet or token enrichment |
+| `compare-tokens` | $0.006 | `mints[]` (2–3) | Side-by-side with rankings and summary picks |
+| `compare-wallets` | $0.006 | `addresses[]` (2–3) | Side-by-side with rankings and summary picks |
+
+## Temporal
+
+| Key | Price | Required input | Returns |
+|---|---|---|---|
+| `token-trend` | $0.006 | `mint` (`lookback`) | Daily snapshots, improving / declining / stable per metric |
+| `wallet-history` | $0.006 | `address` (`lookback`) | Portfolio deltas and position changes |
+| `portfolio-history` | $0.006 | `address` (`period` 7d/14d/30d) | Full value series, peak, trough, max drawdown |
+| `perps-market-trend` | $0.008 | (`lookback`) | Per-market OI, skew, utilization, borrow APR deltas |
+
+## Discovery and signals
+
+| Key | Price | Required input | Returns |
+|---|---|---|---|
+| `new-tokens` | $0.012 | none (`min_liquidity_usd`, `max_risk_score`, `limit`) | Fresh launches enriched and ranked safest first |
+| `trending-signals` | $0.05 | none | DexScreener trending composed with whale flow and risk, ranked with reasoning |
+| `feed-latest` | $0.005 | none (`since`) | Daily pre-computed trending brief, cheap to poll |
+| `consensus-signal` | $0.005 | none (`address`, `window`) | What other agents are querying right now (SolEnrich's own request stream) |
+| `attention-momentum` | $0.02 | none | Agent attention acceleration vs price: early_signal / confirmed / distribution_risk / fading |
+| `check-alerts` | $0.008 | `since` + watchlist (`tokens[]`, `wallets[]`) | Price, whale, concentration, risk, position, and perp alerts since a cursor |
+| `protocol-profile` | $0.008 | `protocol` | TVL, yields, activity, health, automated-activity share |
+| `query` | $0.003 | `question` | Plain English routed to one or more enrichers, unified answer |
+
+## Smart money
+
+| Key | Price | Required input | Returns |
+|---|---|---|---|
+| `smart-money-flow` | $0.10 | none (`wallets[]`, `min_win_rate`, `lookback_days`) | Winners filtered by copy-trade metrics, what they accumulate, clusters |
+| `smart-money-trenches` | $0.05 | none (`hours_back`, `max_token_age_hours`, `min_buyers`, `limit`) | Vetted realized-PnL winners buying tokens younger than 6 hours |
+| `hyperliquid-smart-money` | $0.05 | none (`market`, `top_traders`) | Consistency-gated leaderboard traders' positioning consensus per coin |
+| `hyperliquid-trader-profile` | $0.012 | `address` (0x) | Live positions, leverage, liquidation distance, week/month/all-time PnL |
+
+## Trenches (fresh-launch trade lifecycle)
+
+| Key | Price | Required input | Returns |
+|---|---|---|---|
+| `runner-scan` | $0.04 | none (`max_token_age_hours`, `min_liquidity_usd`, `min_volume_h1_usd`, `limit`) | Fresh tokens whose buying is accelerating: RUNNING / IGNITING / PARABOLIC_LATE / FADING, 0–1 score, `transfer_tax` per runner |
+| `trenches-scan` | $0.08 | none | Velocity × smart money × attention, ranked, HIGH_CONFLUENCE / MODERATE / SINGLE_SIGNAL |
+| `trenches-check` | $0.03 | `mint` | The three legs pointed at one token, with verdict, reasoning, `transfer_tax` |
+| `exit-signal` | $0.04 | `mint` (`entry_price_usd`) | EXIT / DERISK / HOLD, 0–1 exit score, whale flow, `position.net_pnl_after_exit_tax_pct` |
+
+## Perps
+
+| Key | Price | Required input | Returns |
+|---|---|---|---|
+| `perps-market-structure` | $0.012 | none | Jupiter Perps OI, utilization, borrow APR, skew, health per market |
+| `perps-trader-profile` | $0.01 | `address` | Open positions across Jupiter Perps and Adrena, leverage, PnL, classification |
+| `perps-cross-venue-funding` | $0.015 | `market` (SOL/BTC/ETH/BONK) | Funding and OI across Jupiter, Adrena, Flash, Hyperliquid, dYdX; best entry per side; arbitrage |
+| `perps-venue-comparison` | $0.02 | `market`, `side`, `size_usd` | Slippage, fees, OI headroom, total entry cost per venue, recommendation |
+| `perps-basis-signal` | $0.015 | `asset` (`min_yield_apr_pct`) | Net-of-borrow basis yield per venue, best trade |
+
+## StonkFun reward coins (Token-2022 transfer-tax coins paired to xStocks, pre-stocks, ZEC)
+
+| Key | Price | Required input | Returns |
+|---|---|---|---|
+| `stonk-pairs` | free | none (`category`, `launchable_only`) | Quote assets a launch can pair against, `is_agent_launchable` flag |
+| `stonk-gems` | $0.03 | none (`quote_mint`, `category`, `max_age_days`, `min_holders`, `max_market_cap_usd`, `limit`) | Every reward coin scored 0–100: GEM / WATCH / NOISE / DEAD with reasons, warnings, round-trip tax |
+| `stonk-reward-risk` | $0.005 | `mint` | `payout_status` PAYING / STALE / NEVER / NOT_REWARD, `trading_cost`, on-chain fee config, health score |
+| `stonk-yield` | $0.005 | `mint` | Trailing 7d / 30d / lifetime holder yield, quote exposure |
+| `stonk-screener` | $0.01 | none (`quote_mint`, `category`, `paying_only`, `live_only`, `sort`, `limit`, …) | Every reward coin with payout status, live flag, tax cost; sort by volume, last payout, holders, change, yield |
+| `stonk-launch-intel` | $0.02 | none (`category`, `min_coins`, `sort`, `limit`) | Per quote asset: launches, traded and paying shares, survival past day 3, tax mix, crowding, demand score, recommendations |
+| `stonk-launch-preflight` | $0.25 | `unsigned_transaction`, `quote_mint`, `mode` | Diffs a self-built LaunchLab launch against StonkFun's published shape; mismatches with fixes |
+
+## Collectibles
+
+| Key | Price | Required input | Returns |
+|---|---|---|---|
+| `gacha-ev-scan` | $0.02 | none (`machine`, `franchise`, `exit_strategy`, `min_edge_pct`) | Jupiter Gacha pack net EV per machine: POSITIVE_EV / HOUSE_EDGE / NEGATIVE_EV |
+
+## Free surfaces
+
+| Route | What |
+|---|---|
+| `GET /health` | Liveness |
+| `GET /docs` | Every endpoint: input schema, output description, scoring methodology |
+| `GET /openapi.json` | OpenAPI 3.1 with `x-payment-info` per route |
+| `GET /llms.txt` | One paragraph per endpoint for LLM context |
+| `GET /.well-known/x402` | x402 service discovery |
+| `GET /entrypoints` | Key list |
+| `POST /demo/enrich` | One free wallet or token enrichment, 10 per hour per IP |
+| `POST /entrypoints/stonk-pairs/invoke` | Free StonkFun quote-pair catalog |

--- a/skills/solenrich/resources/x402.md
+++ b/skills/solenrich/resources/x402.md
@@ -1,0 +1,95 @@
+# Paying SolEnrich over x402
+
+SolEnrich has no API keys. Every paid route answers HTTP 402 with a payment challenge; the client signs a
+USDC transfer and retries with an `X-Payment` header. The facilitator is Coinbase CDP. Two networks, same
+price, the payer picks:
+
+| Network | Asset | Pay-to (from the 402 body) |
+|---|---|---|
+| Solana mainnet | USDC `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v` | `pricing.networks[0].payTo` |
+| Base (`eip155:8453`) | USDC `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` | `pricing.networks[1].payTo` |
+
+Always read the pay-to address from the 402 response, never hard-code it.
+
+## Option A — TypeScript with `@x402/fetch` (Solana)
+
+```bash
+npm install @x402/fetch @x402/core @x402/svm @solana/kit @scure/base
+```
+
+`examples/x402/pay-per-request.ts` builds a `fetch` that pays automatically. The important detail: register
+the Solana schemes by hand with your own RPC URL. The `registerExactSvmScheme` helper in `@x402/svm`
+drops the `rpcUrl` option, so it always uses the public mainnet-beta RPC, which drops sockets under load
+and surfaces as `Failed to create payment payload: socket connection closed`. A Helius or other paid RPC
+avoids that.
+
+```typescript
+const fetch402 = await createPaidFetch(); // from examples/x402/pay-per-request.ts
+const res = await fetch402('https://api.solenrich.com/entrypoints/enrich-token-light/invoke', {
+  method: 'POST',
+  headers: { 'content-type': 'application/json' },
+  body: JSON.stringify({ mint: 'DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263', format: 'llm' }),
+});
+const data = await res.json();
+```
+
+Environment:
+
+| Variable | Purpose |
+|---|---|
+| `SOLANA_PRIVATE_KEY` | base58 secret key of the paying wallet. Needs USDC plus about 0.01 SOL for fees. |
+| `SOLANA_RPC_URL` | Optional paid RPC. Strongly recommended. |
+
+## Option B — Base with `@x402/evm`
+
+```bash
+npm install @x402/fetch @x402/core @x402/evm viem
+```
+
+Register `ExactEvmScheme` from `@x402/evm/exact/client` on `eip155:8453` with a viem account, wrap
+`fetch` with `wrapFetchWithPayment`, and call the same URLs. The 402 body advertises both networks; the
+client picks the one it has a scheme for.
+
+## Option C — `pay curl` from a terminal (no code)
+
+The Solana Foundation `pay` CLI handles MPP and x402 challenges with a local wallet and an approval
+prompt:
+
+```bash
+npm i -g @solana/pay
+pay wallet create          # once; then fund it with USDC + a little SOL
+pay curl -X POST https://api.solenrich.com/entrypoints/due-diligence/invoke \
+  -H 'content-type: application/json' \
+  -d '{"mint":"DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263","format":"llm"}'
+```
+
+`pay` also ships an MCP server so an assistant can request paid calls through the same approval flow.
+
+## Option D — card via MPP / Stripe
+
+Every route also accepts Machine Payments Protocol challenges (Stripe cards). Use the `mppx` client
+(`npx mppx pay`) if the agent has no crypto wallet.
+
+## Reading a 402
+
+```json
+{
+  "error": "Payment Required",
+  "endpoint": "due-diligence",
+  "pricing": { "amount": "0.02", "currency": "USDC", "network": "solana", "payTo": "...", "networks": [ ... ] },
+  "how_to_pay": { "protocol": "x402", "header": "X-Payment", "facilitator": "..." },
+  "all_endpoints": { "enrich-wallet-light": "$0.002 USDC", "...": "..." }
+}
+```
+
+`all_endpoints` is the full price list, so one unpaid call to any route tells the agent what everything
+costs.
+
+## Spend control
+
+- Prices are fixed per call; there is no metering by response size.
+- Cache windows are 30 s to 10 min by data type. A repeat call inside the window returns the same data and
+  still costs a call.
+- A failed upstream leg does not refund; the response says which leg failed in `caveats`.
+- Keep the paying wallet small and topped up. SolEnrich never sees the private key; the signer runs on
+  the agent's side.


### PR DESCRIPTION
Adds **solenrich** to Data & Analytics: Solana onchain intelligence for agents, pay-per-call over x402 (USDC on Solana or Base) with no API key.

**What the skill covers**
- Token due-diligence with a SAFE / CAUTION / RISKY verdict, holder concentration, slippage at size, Token-2022 transfer tax
- Wallet risk scoring and bot/automation flags, copy-trade metrics
- Smart-money and whale flow on spot, Hyperliquid, and fresh (<6h) launches
- Memecoin trade lifecycle: `runner-scan` → `trenches-check` → `exit-signal` (EXIT / DERISK / HOLD), all tax-aware
- Cross-venue perps funding and venue comparison across Jupiter Perps, Adrena, Flash, Hyperliquid, dYdX
- StonkFun reward coins: gem finder, payout status, screener, launch intel, launch preflight
- `query`: plain-English questions routed to the right enricher

**Files**
- `SKILL.md` — intent → endpoint decision table, payment paths, lifecycle chain, guidelines, common errors
- `resources/endpoints.md` — all 44 paid endpoints + free surfaces with inputs and prices
- `resources/x402.md` — `@x402/fetch` on Solana, `@x402/evm` on Base, `pay curl`, MPP
- `examples/x402/pay-per-request.ts` — the production x402 client SolEnrich's own consumer agent uses (type-checked)
- `examples/trade-lifecycle.md` — one trade, five calls, with a worked example

Same shape as the birdeye and metengine x402 skills. Marketplace entry added in alphabetical order; `scripts/validate-marketplace.js` passes (47 plugins). Live API: https://api.solenrich.com/docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UkDstBPQQvjJs23suuugiw